### PR TITLE
fix(cli): output JSON arrays directly for jq compatibility

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -168,7 +168,13 @@ func (c *SearchCmd) Run(app *App) error {
 	}
 
 	if app.json {
-		return writeJSON(app.out, response)
+		if err := writeJSON(app.out, response.Results); err != nil {
+			return err
+		}
+		if response.NextPageToken != "" {
+			_, _ = fmt.Fprintln(app.err, "next_page_token:", response.NextPageToken)
+		}
+		return nil
 	}
 
 	_, err = fmt.Fprintln(app.out, renderSearch(app.color, response))
@@ -202,7 +208,7 @@ func (c *AutocompleteCmd) Run(app *App) error {
 	}
 
 	if app.json {
-		return writeJSON(app.out, response)
+		return writeJSON(app.out, response.Suggestions)
 	}
 
 	_, err = fmt.Fprintln(app.out, renderAutocomplete(app.color, response))
@@ -234,7 +240,13 @@ func (c *NearbyCmd) Run(app *App) error {
 	}
 
 	if app.json {
-		return writeJSON(app.out, response)
+		if err := writeJSON(app.out, response.Results); err != nil {
+			return err
+		}
+		if response.NextPageToken != "" {
+			_, _ = fmt.Fprintln(app.err, "next_page_token:", response.NextPageToken)
+		}
+		return nil
 	}
 
 	_, err = fmt.Fprintln(app.out, renderNearby(app.color, response))
@@ -296,7 +308,7 @@ func (c *ResolveCmd) Run(app *App) error {
 	}
 
 	if app.json {
-		return writeJSON(app.out, response)
+		return writeJSON(app.out, response.Results)
 	}
 
 	_, err = fmt.Fprintln(app.out, renderResolve(app.color, response))


### PR DESCRIPTION
## Summary

- Changes `--json` output to emit arrays directly instead of wrapper objects
- Makes CLI more compatible with jq pipelines (e.g., `goplaces search "coffee" --json | jq '.[0]'`)
- Writes `next_page_token` to stderr when present, keeping stdout clean for piping

## Changes

- `search`, `nearby`: Output `results` array, write pagination token to stderr
- `autocomplete`: Output `suggestions` array
- `resolve`: Output `results` array
- `details`, `photo`, `route`: Unchanged (already output appropriate structures)

## Breaking Change

Users who parse the wrapped JSON format will need to update their scripts:
- Before: `goplaces search "coffee" --json | jq '.results[0]'`
- After: `goplaces search "coffee" --json | jq '.[0]'`

## Test plan

- [x] All existing tests updated and passing
- [x] New tests added for pagination token stderr output
- [x] Verified jq compatibility with `goplaces search "coffee" --json | jq '.[0]'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)