### PR TITLE
add directions ability to goplaces CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.2 - Unreleased
 
 - Add user rating counts (`user_rating_count`) in search/nearby/details and CLI output (`Rating: 4.5 (532)`). (#3) - thanks @aligurelli
+- Add Directions API support (`goplaces directions`) with walking default, optional steps, and drive comparison.
 
 ## 0.2.1 - 2026-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.2.2 - Unreleased
 
 - Add user rating counts (`user_rating_count`) in search/nearby/details and CLI output (`Rating: 4.5 (532)`). (#3) - thanks @aligurelli
-- Add Directions API support (`goplaces directions`) with walking default, optional steps, and drive comparison.
+- Add Directions API support (`goplaces directions`) with walking default, units control (metric default), optional steps, and drive comparison.
 
 ## 0.2.1 - 2026-01-23
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ goplaces directions --from "Pike Place Market" --to "Space Needle"
 goplaces directions --from-place-id <fromId> --to-place-id <toId> --compare drive --steps
 ```
 
+Units (default metric):
+
+```bash
+goplaces directions --from "Pike Place Market" --to "Space Needle" --units imperial
+```
+
 Details (with reviews):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Modern Go client + CLI for the Google Places API (New). Fast for humans, tidy fo
 - Nearby search around a location restriction.
 - Place photos in details + photo media URLs.
 - Route search along a driving path (Routes API).
+- Directions between two points with distance, duration, and steps (Directions API).
 - Location bias (lat/lng/radius) and pagination tokens.
 - Place details: hours, phone, website, rating, price, types.
 - Optional reviews in details (`--reviews` / `IncludeReviews`).
@@ -35,6 +36,7 @@ Optional overrides:
 
 - `GOOGLE_PLACES_BASE_URL` (testing, proxying, or mock servers)
 - `GOOGLE_ROUTES_BASE_URL` (testing Routes API or proxying)
+- `GOOGLE_DIRECTIONS_BASE_URL` (testing Directions API or proxying)
 
 ### Getting a Google Places API Key
 
@@ -52,18 +54,22 @@ Optional overrides:
    - Search for "Routes API"
    - Click "Enable"
 
-4. **Create an API Key**
+4. **Enable the Directions API (for `directions`)**
+   - Search for "Directions API"
+   - Click "Enable"
+
+5. **Create an API Key**
    - Go to [APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)
    - Click "Create Credentials" → "API Key"
    - Copy the key
 
-5. **Set the Environment Variable**
+6. **Set the Environment Variable**
    ```bash
    export GOOGLE_PLACES_API_KEY="your-api-key-here"
    ```
    Add to your `~/.zshrc` or `~/.bashrc` to persist.
 
-6. **(Recommended) Restrict the Key**
+7. **(Recommended) Restrict the Key**
    - Click on the key in Credentials
    - Under "API restrictions", select "Restrict key" → "Places API (New)"
    - Set quota limits in [Quotas](https://console.cloud.google.com/apis/api/places.googleapis.com/quotas)
@@ -75,7 +81,7 @@ Optional overrides:
 Long flags accept `--flag value` or `--flag=value` (examples use space).
 
 ```text
-goplaces [--api-key=KEY] [--base-url=URL] [--routes-base-url=URL] [--timeout=10s] [--json] [--no-color] [--verbose]
+goplaces [--api-key=KEY] [--base-url=URL] [--routes-base-url=URL] [--directions-base-url=URL] [--timeout=10s] [--json] [--no-color] [--verbose]
          <command>
 
 Commands:
@@ -83,6 +89,7 @@ Commands:
   nearby        Search nearby places by location.
   search   Search places by text query.
   route    Search places along a route.
+  directions  Get directions between two points.
   details  Fetch place details by place ID.
   photo    Fetch a photo URL by photo name.
   resolve  Resolve a location string to candidate places.
@@ -117,6 +124,13 @@ Route search:
 
 ```bash
 goplaces route "coffee" --from "Seattle, WA" --to "Portland, OR" --max-waypoints 5
+```
+
+Directions (walking with optional driving comparison):
+
+```bash
+goplaces directions --from "Pike Place Market" --to "Space Needle"
+goplaces directions --from-place-id <fromId> --to-place-id <toId> --compare drive --steps
 ```
 
 Details (with reviews):

--- a/client.go
+++ b/client.go
@@ -19,19 +19,21 @@ const DefaultBaseURL = "https://places.googleapis.com/v1"
 
 // Client wraps access to the Google Places API.
 type Client struct {
-	apiKey        string
-	baseURL       string
-	routesBaseURL string
-	httpClient    *http.Client
+	apiKey            string
+	baseURL           string
+	routesBaseURL     string
+	directionsBaseURL string
+	httpClient        *http.Client
 }
 
 // Options configures the Places client.
 type Options struct {
-	APIKey        string
-	BaseURL       string
-	RoutesBaseURL string
-	HTTPClient    *http.Client
-	Timeout       time.Duration
+	APIKey            string
+	BaseURL           string
+	RoutesBaseURL     string
+	DirectionsBaseURL string
+	HTTPClient        *http.Client
+	Timeout           time.Duration
 }
 
 // NewClient builds a client with sane defaults.
@@ -44,6 +46,10 @@ func NewClient(opts Options) *Client {
 	if routesBaseURL == "" {
 		routesBaseURL = defaultRoutesBaseURL
 	}
+	directionsBaseURL := strings.TrimRight(opts.DirectionsBaseURL, "/")
+	if directionsBaseURL == "" {
+		directionsBaseURL = defaultDirectionsBaseURL
+	}
 
 	client := opts.HTTPClient
 	if client == nil {
@@ -55,10 +61,11 @@ func NewClient(opts Options) *Client {
 	}
 
 	return &Client{
-		apiKey:        opts.APIKey,
-		baseURL:       baseURL,
-		routesBaseURL: routesBaseURL,
-		httpClient:    client,
+		apiKey:            opts.APIKey,
+		baseURL:           baseURL,
+		routesBaseURL:     routesBaseURL,
+		directionsBaseURL: directionsBaseURL,
+		httpClient:        client,
 	}
 }
 

--- a/directions.go
+++ b/directions.go
@@ -24,11 +24,21 @@ const (
 	directionsModeTransit = "transit"
 )
 
+const (
+	directionsUnitsMetric   = "metric"
+	directionsUnitsImperial = "imperial"
+)
+
 var directionsModes = map[string]struct{}{
 	directionsModeWalk:    {},
 	directionsModeDrive:   {},
 	directionsModeBicycle: {},
 	directionsModeTransit: {},
+}
+
+var directionsUnits = map[string]struct{}{
+	directionsUnitsMetric:   {},
+	directionsUnitsImperial: {},
 }
 
 // DirectionsRequest describes a directions query between two locations.
@@ -166,6 +176,9 @@ func applyDirectionsDefaults(req DirectionsRequest) DirectionsRequest {
 	if req.Units != "" {
 		req.Units = strings.ToLower(strings.TrimSpace(req.Units))
 	}
+	if req.Units == "" {
+		req.Units = directionsUnitsMetric
+	}
 	return req
 }
 
@@ -179,8 +192,10 @@ func validateDirectionsRequest(req DirectionsRequest) error {
 	if err := validateDirectionsLocation("to", req.ToPlaceID, req.ToLocation, req.To); err != nil {
 		return err
 	}
-	if req.Units != "" && req.Units != "metric" && req.Units != "imperial" {
-		return ValidationError{Field: "units", Message: "must be metric or imperial"}
+	if req.Units != "" {
+		if _, ok := directionsUnits[req.Units]; !ok {
+			return ValidationError{Field: "units", Message: "must be metric or imperial"}
+		}
 	}
 	return nil
 }

--- a/directions.go
+++ b/directions.go
@@ -1,0 +1,341 @@
+package goplaces
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	defaultDirectionsBaseURL = "https://maps.googleapis.com/maps/api/directions/json"
+)
+
+const (
+	directionsModeWalk    = "walking"
+	directionsModeDrive   = "driving"
+	directionsModeBicycle = "bicycling"
+	directionsModeTransit = "transit"
+)
+
+var directionsModes = map[string]struct{}{
+	directionsModeWalk:    {},
+	directionsModeDrive:   {},
+	directionsModeBicycle: {},
+	directionsModeTransit: {},
+}
+
+// DirectionsRequest describes a directions query between two locations.
+type DirectionsRequest struct {
+	From         string  `json:"from,omitempty"`
+	To           string  `json:"to,omitempty"`
+	FromPlaceID  string  `json:"from_place_id,omitempty"`
+	ToPlaceID    string  `json:"to_place_id,omitempty"`
+	FromLocation *LatLng `json:"from_location,omitempty"`
+	ToLocation   *LatLng `json:"to_location,omitempty"`
+	Mode         string  `json:"mode,omitempty"`
+	Language     string  `json:"language,omitempty"`
+	Region       string  `json:"region,omitempty"`
+	Units        string  `json:"units,omitempty"`
+}
+
+// DirectionsResponse contains a single route summary and steps.
+type DirectionsResponse struct {
+	Mode            string           `json:"mode"`
+	Summary         string           `json:"summary,omitempty"`
+	StartAddress    string           `json:"start_address,omitempty"`
+	EndAddress      string           `json:"end_address,omitempty"`
+	DistanceText    string           `json:"distance_text,omitempty"`
+	DistanceMeters  int              `json:"distance_meters,omitempty"`
+	DurationText    string           `json:"duration_text,omitempty"`
+	DurationSeconds int              `json:"duration_seconds,omitempty"`
+	Warnings        []string         `json:"warnings,omitempty"`
+	Steps           []DirectionsStep `json:"steps,omitempty"`
+}
+
+// DirectionsStep is a single navigation step.
+type DirectionsStep struct {
+	Instruction     string `json:"instruction,omitempty"`
+	DistanceText    string `json:"distance_text,omitempty"`
+	DistanceMeters  int    `json:"distance_meters,omitempty"`
+	DurationText    string `json:"duration_text,omitempty"`
+	DurationSeconds int    `json:"duration_seconds,omitempty"`
+	TravelMode      string `json:"travel_mode,omitempty"`
+	Maneuver        string `json:"maneuver,omitempty"`
+}
+
+// Directions fetches directions between two locations using the Google Directions API.
+func (c *Client) Directions(ctx context.Context, req DirectionsRequest) (DirectionsResponse, error) {
+	req = applyDirectionsDefaults(req)
+	if err := validateDirectionsRequest(req); err != nil {
+		return DirectionsResponse{}, err
+	}
+
+	origin, err := resolveDirectionsLocation("from", req.FromPlaceID, req.FromLocation, req.From)
+	if err != nil {
+		return DirectionsResponse{}, err
+	}
+	destination, err := resolveDirectionsLocation("to", req.ToPlaceID, req.ToLocation, req.To)
+	if err != nil {
+		return DirectionsResponse{}, err
+	}
+
+	query := map[string]string{
+		"origin":      origin,
+		"destination": destination,
+		"mode":        req.Mode,
+	}
+	if strings.TrimSpace(req.Language) != "" {
+		query["language"] = req.Language
+	}
+	if strings.TrimSpace(req.Region) != "" {
+		query["region"] = req.Region
+	}
+	if strings.TrimSpace(req.Units) != "" {
+		query["units"] = req.Units
+	}
+
+	endpoint, err := buildDirectionsURL(c.directionsBaseURL, query, c.apiKey)
+	if err != nil {
+		return DirectionsResponse{}, err
+	}
+
+	payload, err := c.doDirectionsRequest(ctx, endpoint)
+	if err != nil {
+		return DirectionsResponse{}, err
+	}
+
+	var apiResponse directionsAPIResponse
+	if err := json.Unmarshal(payload, &apiResponse); err != nil {
+		return DirectionsResponse{}, fmt.Errorf("goplaces: decode directions response: %w", err)
+	}
+	if apiResponse.Status != "OK" {
+		return DirectionsResponse{}, fmt.Errorf("goplaces: directions status %s: %s", apiResponse.Status, strings.TrimSpace(apiResponse.ErrorMessage))
+	}
+	if len(apiResponse.Routes) == 0 || len(apiResponse.Routes[0].Legs) == 0 {
+		return DirectionsResponse{}, errors.New("goplaces: no directions returned")
+	}
+
+	route := apiResponse.Routes[0]
+	leg := route.Legs[0]
+	steps := make([]DirectionsStep, 0, len(leg.Steps))
+	for _, step := range leg.Steps {
+		steps = append(steps, DirectionsStep{
+			Instruction:     cleanInstruction(step.HTMLInstructions),
+			DistanceText:    step.Distance.Text,
+			DistanceMeters:  step.Distance.Value,
+			DurationText:    step.Duration.Text,
+			DurationSeconds: step.Duration.Value,
+			TravelMode:      step.TravelMode,
+			Maneuver:        step.Maneuver,
+		})
+	}
+
+	return DirectionsResponse{
+		Mode:            strings.ToUpper(req.Mode),
+		Summary:         route.Summary,
+		StartAddress:    leg.StartAddress,
+		EndAddress:      leg.EndAddress,
+		DistanceText:    leg.Distance.Text,
+		DistanceMeters:  leg.Distance.Value,
+		DurationText:    leg.Duration.Text,
+		DurationSeconds: leg.Duration.Value,
+		Warnings:        route.Warnings,
+		Steps:           steps,
+	}, nil
+}
+
+func applyDirectionsDefaults(req DirectionsRequest) DirectionsRequest {
+	req.From = strings.TrimSpace(req.From)
+	req.To = strings.TrimSpace(req.To)
+	req.FromPlaceID = strings.TrimSpace(req.FromPlaceID)
+	req.ToPlaceID = strings.TrimSpace(req.ToPlaceID)
+	req.Mode = strings.ToLower(strings.TrimSpace(req.Mode))
+	if req.Mode == "" {
+		req.Mode = directionsModeWalk
+	}
+	if normalized := normalizeDirectionsMode(req.Mode); normalized != "" {
+		req.Mode = normalized
+	}
+	if req.Units != "" {
+		req.Units = strings.ToLower(strings.TrimSpace(req.Units))
+	}
+	return req
+}
+
+func validateDirectionsRequest(req DirectionsRequest) error {
+	if normalizeDirectionsMode(req.Mode) == "" {
+		return ValidationError{Field: "mode", Message: "must be walk, drive, bicycle, or transit"}
+	}
+	if err := validateDirectionsLocation("from", req.FromPlaceID, req.FromLocation, req.From); err != nil {
+		return err
+	}
+	if err := validateDirectionsLocation("to", req.ToPlaceID, req.ToLocation, req.To); err != nil {
+		return err
+	}
+	if req.Units != "" && req.Units != "metric" && req.Units != "imperial" {
+		return ValidationError{Field: "units", Message: "must be metric or imperial"}
+	}
+	return nil
+}
+
+func validateDirectionsLocation(label string, placeID string, location *LatLng, text string) error {
+	provided := 0
+	if strings.TrimSpace(placeID) != "" {
+		provided++
+	}
+	if location != nil {
+		provided++
+		if location.Lat < -90 || location.Lat > 90 {
+			return ValidationError{Field: label + ".lat", Message: "must be -90..90"}
+		}
+		if location.Lng < -180 || location.Lng > 180 {
+			return ValidationError{Field: label + ".lng", Message: "must be -180..180"}
+		}
+	}
+	if strings.TrimSpace(text) != "" {
+		provided++
+	}
+	if provided == 0 {
+		return ValidationError{Field: label, Message: "required"}
+	}
+	if provided > 1 {
+		return ValidationError{Field: label, Message: "use only one of text, place_id, or lat/lng"}
+	}
+	return nil
+}
+
+func resolveDirectionsLocation(label string, placeID string, location *LatLng, text string) (string, error) {
+	if err := validateDirectionsLocation(label, placeID, location, text); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(placeID) != "" {
+		return "place_id:" + strings.TrimSpace(placeID), nil
+	}
+	if location != nil {
+		return fmt.Sprintf("%.6f,%.6f", location.Lat, location.Lng), nil
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func normalizeDirectionsMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "walk", "walking":
+		return directionsModeWalk
+	case "drive", "driving":
+		return directionsModeDrive
+	case "bike", "bicycle", "bicycling":
+		return directionsModeBicycle
+	case "transit":
+		return directionsModeTransit
+	default:
+		return ""
+	}
+}
+
+func buildDirectionsURL(base string, query map[string]string, apiKey string) (string, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return "", ErrMissingAPIKey
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("goplaces: invalid directions url: %w", err)
+	}
+	values := parsed.Query()
+	for key, value := range query {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		values.Set(key, value)
+	}
+	values.Set("key", apiKey)
+	parsed.RawQuery = values.Encode()
+	return parsed.String(), nil
+}
+
+func (c *Client) doDirectionsRequest(ctx context.Context, endpoint string) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("goplaces: build directions request: %w", err)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("goplaces: directions request failed: %w", err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	payload, err := readResponseBody(response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode >= http.StatusBadRequest {
+		apiErr := &APIError{StatusCode: response.StatusCode, Body: strings.TrimSpace(string(payload))}
+		return nil, apiErr
+	}
+
+	return payload, nil
+}
+
+type directionsAPIResponse struct {
+	Status       string            `json:"status"`
+	ErrorMessage string            `json:"error_message,omitempty"`
+	Routes       []directionsRoute `json:"routes"`
+}
+
+type directionsRoute struct {
+	Summary  string          `json:"summary,omitempty"`
+	Warnings []string        `json:"warnings,omitempty"`
+	Legs     []directionsLeg `json:"legs"`
+}
+
+type directionsLeg struct {
+	Distance     directionsValue  `json:"distance"`
+	Duration     directionsValue  `json:"duration"`
+	StartAddress string           `json:"start_address,omitempty"`
+	EndAddress   string           `json:"end_address,omitempty"`
+	Steps        []directionsStep `json:"steps"`
+}
+
+type directionsStep struct {
+	HTMLInstructions string          `json:"html_instructions,omitempty"`
+	Distance         directionsValue `json:"distance"`
+	Duration         directionsValue `json:"duration"`
+	TravelMode       string          `json:"travel_mode,omitempty"`
+	Maneuver         string          `json:"maneuver,omitempty"`
+}
+
+type directionsValue struct {
+	Text  string `json:"text,omitempty"`
+	Value int    `json:"value,omitempty"`
+}
+
+var htmlTagPattern = regexp.MustCompile(`<[^>]+>`)
+
+func cleanInstruction(input string) string {
+	cleaned := htmlTagPattern.ReplaceAllString(input, "")
+	cleaned = html.UnescapeString(cleaned)
+	cleaned = strings.TrimSpace(cleaned)
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	return cleaned
+}
+
+func readResponseBody(response *http.Response) ([]byte, error) {
+	payload, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("goplaces: read response: %w", err)
+	}
+	if len(payload) == 0 {
+		return nil, errors.New("goplaces: empty response")
+	}
+	return payload, nil
+}

--- a/directions_test.go
+++ b/directions_test.go
@@ -19,6 +19,9 @@ func TestDirectionsRequestPlaceID(t *testing.T) {
 		if query.Get("mode") != directionsModeWalk {
 			t.Fatalf("unexpected mode: %s", query.Get("mode"))
 		}
+		if query.Get("units") != directionsUnitsMetric {
+			t.Fatalf("unexpected units: %s", query.Get("units"))
+		}
 		if query.Get("key") != "test-key" {
 			t.Fatalf("unexpected key: %s", query.Get("key"))
 		}
@@ -69,6 +72,13 @@ func TestDirectionsModeValidation(t *testing.T) {
 		t.Fatalf("expected empty normalization")
 	}
 	req := DirectionsRequest{From: "A", To: "B", Mode: "plane"}
+	if err := validateDirectionsRequest(applyDirectionsDefaults(req)); err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestDirectionsUnitsValidation(t *testing.T) {
+	req := DirectionsRequest{From: "A", To: "B", Units: "fathoms"}
 	if err := validateDirectionsRequest(applyDirectionsDefaults(req)); err == nil {
 		t.Fatalf("expected validation error")
 	}

--- a/directions_test.go
+++ b/directions_test.go
@@ -1,0 +1,82 @@
+package goplaces
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDirectionsRequestPlaceID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if query.Get("origin") != "place_id:from" {
+			t.Fatalf("unexpected origin: %s", query.Get("origin"))
+		}
+		if query.Get("destination") != "place_id:to" {
+			t.Fatalf("unexpected destination: %s", query.Get("destination"))
+		}
+		if query.Get("mode") != directionsModeWalk {
+			t.Fatalf("unexpected mode: %s", query.Get("mode"))
+		}
+		if query.Get("key") != "test-key" {
+			t.Fatalf("unexpected key: %s", query.Get("key"))
+		}
+		_, _ = w.Write([]byte(`{
+			"status": "OK",
+			"routes": [{
+				"summary": "Main",
+				"warnings": ["test"],
+				"legs": [{
+					"distance": {"text": "1 km", "value": 1000},
+					"duration": {"text": "10 mins", "value": 600},
+					"start_address": "Start",
+					"end_address": "End",
+					"steps": [{
+						"html_instructions": "Head <b>north</b>",
+						"distance": {"text": "0.2 km", "value": 200},
+						"duration": {"text": "2 mins", "value": 120},
+						"travel_mode": "WALKING"
+					}]
+				}]
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Options{APIKey: "test-key", DirectionsBaseURL: server.URL})
+	response, err := client.Directions(context.Background(), DirectionsRequest{
+		FromPlaceID: "from",
+		ToPlaceID:   "to",
+		Mode:        "walk",
+	})
+	if err != nil {
+		t.Fatalf("Directions error: %v", err)
+	}
+	if response.DistanceMeters != 1000 {
+		t.Fatalf("unexpected distance: %d", response.DistanceMeters)
+	}
+	if len(response.Steps) != 1 || response.Steps[0].Instruction != "Head north" {
+		t.Fatalf("unexpected steps: %#v", response.Steps)
+	}
+	if response.Mode != "WALKING" {
+		t.Fatalf("unexpected mode: %s", response.Mode)
+	}
+}
+
+func TestDirectionsModeValidation(t *testing.T) {
+	if normalizeDirectionsMode("plane") != "" {
+		t.Fatalf("expected empty normalization")
+	}
+	req := DirectionsRequest{From: "A", To: "B", Mode: "plane"}
+	if err := validateDirectionsRequest(applyDirectionsDefaults(req)); err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestDirectionsLocationValidation(t *testing.T) {
+	req := DirectionsRequest{FromPlaceID: "a", From: "b", To: "c"}
+	if err := validateDirectionsRequest(applyDirectionsDefaults(req)); err == nil {
+		t.Fatalf("expected validation error for multiple origin inputs")
+	}
+}

--- a/docs/directions.md
+++ b/docs/directions.md
@@ -1,0 +1,34 @@
+# Directions
+
+Use the Directions API (legacy) to get distance, duration, and step-by-step instructions.
+
+## Enable the API
+
+- Enable **Directions API** in Google Cloud Console for the same project as Places.
+- Use the same `GOOGLE_PLACES_API_KEY` (recommended).
+
+## Examples
+
+Walking summary:
+
+```bash
+goplaces directions --from "Pike Place Market" --to "Space Needle"
+```
+
+Place ID driven:
+
+```bash
+goplaces directions --from-place-id <fromId> --to-place-id <toId>
+```
+
+Walking with driving comparison + steps:
+
+```bash
+goplaces directions --from-place-id <fromId> --to-place-id <toId> --compare drive --steps
+```
+
+## Notes
+
+- Default mode is walking.
+- Use `--steps` for turn-by-turn instructions.
+- Use `--compare drive` to add a driving ETA.

--- a/docs/directions.md
+++ b/docs/directions.md
@@ -27,8 +27,15 @@ Walking with driving comparison + steps:
 goplaces directions --from-place-id <fromId> --to-place-id <toId> --compare drive --steps
 ```
 
+Imperial units:
+
+```bash
+goplaces directions --from-place-id <fromId> --to-place-id <toId> --units imperial
+```
+
 ## Notes
 
 - Default mode is walking.
+- Default units are metric (use `--units imperial` for miles/feet).
 - Use `--steps` for turn-by-turn instructions.
 - Use `--compare drive` to add a driving ETA.

--- a/internal/cli/directions.go
+++ b/internal/cli/directions.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/steipete/goplaces"
+)
+
+// DirectionsCmd fetches directions between two points.
+type DirectionsCmd struct {
+	From        string   `help:"Origin address or place name."`
+	To          string   `help:"Destination address or place name."`
+	FromPlaceID string   `help:"Origin place ID." name:"from-place-id"`
+	ToPlaceID   string   `help:"Destination place ID." name:"to-place-id"`
+	FromLat     *float64 `help:"Origin latitude." name:"from-lat"`
+	FromLng     *float64 `help:"Origin longitude." name:"from-lng"`
+	ToLat       *float64 `help:"Destination latitude." name:"to-lat"`
+	ToLng       *float64 `help:"Destination longitude." name:"to-lng"`
+	Mode        string   `help:"Travel mode: walk, drive, bicycle, transit." default:"walk"`
+	Compare     string   `help:"Compare with another mode: walk, drive, bicycle, transit."`
+	Steps       bool     `help:"Include step-by-step instructions."`
+	Language    string   `help:"BCP-47 language code (e.g. en, en-US)."`
+	Region      string   `help:"CLDR region code (e.g. US, DE)."`
+}
+
+// Run executes the directions command.
+func (c *DirectionsCmd) Run(app *App) error {
+	primaryMode := normalizeDirectionsMode(c.Mode)
+	if primaryMode == "" {
+		return goplaces.ValidationError{Field: "mode", Message: "must be walk, drive, bicycle, or transit"}
+	}
+	compareMode := ""
+	if strings.TrimSpace(c.Compare) != "" {
+		compareMode = normalizeDirectionsMode(c.Compare)
+		if compareMode == "" {
+			return goplaces.ValidationError{Field: "compare", Message: "must be walk, drive, bicycle, or transit"}
+		}
+		if compareMode == primaryMode {
+			return goplaces.ValidationError{Field: "compare", Message: "must be different from mode"}
+		}
+	}
+
+	request := goplaces.DirectionsRequest{
+		From:        c.From,
+		To:          c.To,
+		FromPlaceID: c.FromPlaceID,
+		ToPlaceID:   c.ToPlaceID,
+		Mode:        primaryMode,
+		Language:    c.Language,
+		Region:      c.Region,
+	}
+	if c.FromLat != nil || c.FromLng != nil {
+		if c.FromLat == nil || c.FromLng == nil {
+			return goplaces.ValidationError{Field: "from_location", Message: "lat and lng required"}
+		}
+		request.FromLocation = &goplaces.LatLng{Lat: *c.FromLat, Lng: *c.FromLng}
+	}
+	if c.ToLat != nil || c.ToLng != nil {
+		if c.ToLat == nil || c.ToLng == nil {
+			return goplaces.ValidationError{Field: "to_location", Message: "lat and lng required"}
+		}
+		request.ToLocation = &goplaces.LatLng{Lat: *c.ToLat, Lng: *c.ToLng}
+	}
+
+	response, err := app.client.Directions(context.Background(), request)
+	if err != nil {
+		return err
+	}
+
+	var compareResponse *goplaces.DirectionsResponse
+	if compareMode != "" {
+		compareRequest := request
+		compareRequest.Mode = compareMode
+		second, err := app.client.Directions(context.Background(), compareRequest)
+		if err != nil {
+			return err
+		}
+		compareResponse = &second
+	}
+
+	if app.json {
+		if compareResponse != nil {
+			return writeJSON(app.out, []goplaces.DirectionsResponse{response, *compareResponse})
+		}
+		return writeJSON(app.out, response)
+	}
+
+	if compareResponse != nil {
+		_, err = app.out.Write([]byte(renderDirections(app.color, response, c.Steps)))
+		if err != nil {
+			return err
+		}
+		_, err = app.out.Write([]byte("\n\n" + renderDirections(app.color, *compareResponse, c.Steps)))
+		return err
+	}
+
+	_, err = app.out.Write([]byte(renderDirections(app.color, response, c.Steps)))
+	return err
+}
+
+func normalizeDirectionsMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "walk", "walking":
+		return "walking"
+	case "drive", "driving":
+		return "driving"
+	case "bike", "bicycle", "bicycling":
+		return "bicycling"
+	case "transit":
+		return "transit"
+	default:
+		return ""
+	}
+}

--- a/internal/cli/directions.go
+++ b/internal/cli/directions.go
@@ -20,6 +20,7 @@ type DirectionsCmd struct {
 	Mode        string   `help:"Travel mode: walk, drive, bicycle, transit." default:"walk"`
 	Compare     string   `help:"Compare with another mode: walk, drive, bicycle, transit."`
 	Steps       bool     `help:"Include step-by-step instructions."`
+	Units       string   `help:"Units: metric or imperial." default:"metric"`
 	Language    string   `help:"BCP-47 language code (e.g. en, en-US)."`
 	Region      string   `help:"CLDR region code (e.g. US, DE)."`
 }
@@ -47,6 +48,7 @@ func (c *DirectionsCmd) Run(app *App) error {
 		FromPlaceID: c.FromPlaceID,
 		ToPlaceID:   c.ToPlaceID,
 		Mode:        primaryMode,
+		Units:       c.Units,
 		Language:    c.Language,
 		Region:      c.Region,
 	}

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -154,6 +154,29 @@ func TestRenderRouteEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderDirections(t *testing.T) {
+	response := goplaces.DirectionsResponse{
+		Mode:         "WALKING",
+		StartAddress: "Start",
+		EndAddress:   "End",
+		DistanceText: "1 km",
+		DurationText: "10 mins",
+		Steps: []goplaces.DirectionsStep{
+			{Instruction: "Head north", DistanceText: "0.2 km", DurationText: "2 mins"},
+		},
+	}
+	output := renderDirections(NewColor(false), response, true)
+	if !strings.Contains(output, "Directions") {
+		t.Fatalf("missing directions header")
+	}
+	if !strings.Contains(output, "Head north") {
+		t.Fatalf("missing step")
+	}
+	if !strings.Contains(output, "Distance") {
+		t.Fatalf("missing distance")
+	}
+}
+
 func TestFormatTitleFallback(t *testing.T) {
 	title := formatTitle(NewColor(false), "", "")
 	if !strings.Contains(title, "(no name)") {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ type Root struct {
 	Nearby       NearbyCmd       `cmd:"" help:"Search nearby places by location."`
 	Search       SearchCmd       `cmd:"" help:"Search places by text query."`
 	Route        RouteCmd        `cmd:"" help:"Search places along a route."`
+	Directions   DirectionsCmd   `cmd:"" help:"Get directions and travel time between two points."`
 	Details      DetailsCmd      `cmd:"" help:"Fetch place details by place ID."`
 	Photo        PhotoCmd        `cmd:"" help:"Fetch a photo URL by photo name."`
 	Resolve      ResolveCmd      `cmd:"" help:"Resolve a location string to candidate places."`
@@ -18,14 +19,15 @@ type Root struct {
 
 // GlobalOptions are flags shared by all commands.
 type GlobalOptions struct {
-	APIKey        string        `help:"Google Places API key." env:"GOOGLE_PLACES_API_KEY"`
-	BaseURL       string        `help:"Places API base URL." env:"GOOGLE_PLACES_BASE_URL" default:"https://places.googleapis.com/v1"`
-	RoutesBaseURL string        `help:"Routes API base URL." env:"GOOGLE_ROUTES_BASE_URL" default:"https://routes.googleapis.com"`
-	Timeout       time.Duration `help:"HTTP timeout." default:"10s"`
-	JSON          bool          `help:"Output JSON."`
-	NoColor       bool          `help:"Disable color output."`
-	Verbose       bool          `help:"Verbose logging."`
-	Version       VersionFlag   `name:"version" help:"Print version and exit."`
+	APIKey            string        `help:"Google Places API key." env:"GOOGLE_PLACES_API_KEY"`
+	BaseURL           string        `help:"Places API base URL." env:"GOOGLE_PLACES_BASE_URL" default:"https://places.googleapis.com/v1"`
+	RoutesBaseURL     string        `help:"Routes API base URL." env:"GOOGLE_ROUTES_BASE_URL" default:"https://routes.googleapis.com"`
+	DirectionsBaseURL string        `help:"Directions API base URL." env:"GOOGLE_DIRECTIONS_BASE_URL" default:"https://maps.googleapis.com/maps/api/directions/json"`
+	Timeout           time.Duration `help:"HTTP timeout." default:"10s"`
+	JSON              bool          `help:"Output JSON."`
+	NoColor           bool          `help:"Disable color output."`
+	Verbose           bool          `help:"Verbose logging."`
+	Version           VersionFlag   `name:"version" help:"Print version and exit."`
 }
 
 // SearchCmd runs text search queries.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -69,10 +69,11 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	client := goplaces.NewClient(goplaces.Options{
-		APIKey:        root.Global.APIKey,
-		BaseURL:       root.Global.BaseURL,
-		RoutesBaseURL: root.Global.RoutesBaseURL,
-		Timeout:       root.Global.Timeout,
+		APIKey:            root.Global.APIKey,
+		BaseURL:           root.Global.BaseURL,
+		RoutesBaseURL:     root.Global.RoutesBaseURL,
+		DirectionsBaseURL: root.Global.DirectionsBaseURL,
+		Timeout:           root.Global.Timeout,
 	})
 
 	app := &App{


### PR DESCRIPTION
i wanted to have directions in goplaces for obvious reasons. this adds it!


# Human written summary:
The intent of this change is, as written by a human:
> add directions ability to goplaces CLI

_The rest of this PR was written by gpt5.2-high, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- add Directions API command with walking default, steps, and optional drive comparison
- add `--units metric|imperial` (default metric) for human-readable output
- document directions usage + units flag
- Example output (walking, metric default):

```bash
goplaces directions --from-place-id ChIJaasyI4aAhYARSkMTdc_1FyU \
  --to-place-id ChIJFwoupK-BhYARMWbdafFyOtc --steps --no-color
```

```
Directions (WALKING)
From: 12 4th St, San Francisco, CA 94103, USA
To: 995 Market St, San Francisco, CA 94103, USA
Summary: Market St
Distance: 0.6 km
Duration: 9 mins
Warnings:
  - Walking directions are in beta. Use caution – This route may be missing sidewalks or pedestrian paths.
Steps:
  1. Head northwest on 4th St toward Market StMay be closed at certain times or days · 58 m · 1 min
  2. Turn left onto Market St · 0.6 km · 8 mins
  3. Turn left onto 6th St · 16 m · 1 min
```

# Tests
- `go test ./...`

# Risks
- Defaulting to metric changes human-readable units for existing users.

# Follow-ups
- None

# Prompt History

Prompt history collected from agent session logs.

## Environment
Harness: pi
Model: gpt5.2
Thinking level: high
Terminal: ghostty
System: ma

PR: "add directions ability to goplaces CLI".

Include example outputs too in the body to show how it works, including with CLI flags you can use my hotel to the frontier tower example.` |
| 2026-02-04T19:03:51Z | `yes. open as ready` |

