### PR TITLE
feat: add directions departure and arrival time flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ goplaces directions --from "Paris" --to "Brest" --mode drive --avoid-tolls
 goplaces directions --from "Paris" --to "Brest" --mode drive --avoid-highways --avoid-ferries
 ```
 
+Time-aware routing:
+
+```bash
+goplaces directions --from "GIG Airport" --to "Leblon, Rio de Janeiro" --mode drive --departure-time "2026-05-10T18:57:00-03:00"
+goplaces directions --from "Pike Place Market" --to "Space Needle" --arrival-time "2026-05-10T19:30:00-07:00"
+```
+
 Units (default metric):
 
 ```bash

--- a/docs/directions.md
+++ b/docs/directions.md
@@ -40,10 +40,18 @@ goplaces directions --from "Paris" --to "Brest" --mode drive --avoid-tolls
 goplaces directions --from "Paris" --to "Brest" --mode drive --avoid-highways --avoid-ferries
 ```
 
+Time-aware routing:
+
+```bash
+goplaces directions --from "GIG Airport" --to "Leblon, Rio de Janeiro" --mode drive --departure-time "2026-05-10T18:57:00-03:00"
+goplaces directions --from "Pike Place Market" --to "Space Needle" --arrival-time "2026-05-10T19:30:00-07:00"
+```
+
 ## Notes
 
 - Default mode is walking.
 - Default units are metric (use `--units imperial` for miles/feet).
 - Use `--steps` for turn-by-turn instructions.
 - Use `--compare drive` to add a driving ETA.
+- Use `--departure-time` or `--arrival-time` with an RFC3339 timestamp to request time-aware routing. The two flags are mutually exclusive.
 - Use `--avoid-tolls`, `--avoid-highways`, and `--avoid-ferries` with `--mode drive` to request drive routes that avoid those features when reasonable.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -400,6 +400,56 @@ func TestRunDirectionsJSON(t *testing.T) {
 	}
 }
 
+func TestRunDirectionsWithDepartureTime(t *testing.T) {
+	const departure = "2026-05-10T18:57:00-03:00"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != directionsPath {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload["departureTime"] != departure {
+			t.Fatalf("unexpected departure time: %#v", payload["departureTime"])
+		}
+		if payload["routingPreference"] != "TRAFFIC_AWARE" {
+			t.Fatalf("unexpected routing preference: %#v", payload["routingPreference"])
+		}
+		_, _ = w.Write([]byte(`{
+  "routes":[{"description":"Main","legs":[{"distanceMeters":26084,"duration":"2215s","localizedValues":{"distance":{"text":"26.1 km"},"duration":{"text":"37 mins"}},"steps":[]}]}]
+}`))
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{
+		"directions",
+		"--from-lat=-22.8112259",
+		"--from-lng=-43.2585631",
+		"--to-lat=-22.9837626",
+		"--to-lng=-43.2322048",
+		"--mode", "drive",
+		"--departure-time", departure,
+		"--api-key", "test-key",
+		"--directions-base-url", server.URL,
+		"--json",
+	}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d (stdout=%s stderr=%s)", exitCode, stdout.String(), stderr.String())
+	}
+	var result goplaces.DirectionsResponse
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode output: %v (stdout=%s)", err, stdout.String())
+	}
+	if result.DepartureTime != departure || result.DurationSeconds != 2215 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
 func TestRunDirectionsCompareJSON(t *testing.T) {
 	seenModes := make(map[string]int)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -522,6 +572,14 @@ func TestRunDirectionsValidationErrors(t *testing.T) {
 		{
 			name: "partial to latlng",
 			args: []string{"directions", "--from", "A", "--to-lng", "2", "--api-key", "x"},
+		},
+		{
+			name: "departure and arrival",
+			args: []string{"directions", "--from", "A", "--to", "B", "--departure-time", "2026-05-10T18:57:00-03:00", "--arrival-time", "2026-05-10T19:57:00-03:00", "--api-key", "x"},
+		},
+		{
+			name: "invalid departure time",
+			args: []string{"directions", "--from", "A", "--to", "B", "--departure-time", "tomorrow", "--api-key", "x"},
 		},
 	}
 

--- a/internal/cli/directions.go
+++ b/internal/cli/directions.go
@@ -24,6 +24,8 @@ type DirectionsCmd struct {
 	AvoidTolls    bool     `help:"Avoid toll roads when driving."`
 	AvoidHighways bool     `help:"Avoid highways when driving."`
 	AvoidFerries  bool     `help:"Avoid ferries when driving."`
+	DepartureTime string   `help:"Route departure time as RFC3339 timestamp (for example 2026-05-10T18:57:00-03:00)." name:"departure-time"`
+	ArrivalTime   string   `help:"Route arrival time as RFC3339 timestamp; mutually exclusive with --departure-time." name:"arrival-time"`
 	Language      string   `help:"BCP-47 language code (e.g. en, en-US)."`
 	Region        string   `help:"CLDR region code (e.g. US, DE)."`
 }
@@ -55,6 +57,8 @@ func (c *DirectionsCmd) Run(app *App) error {
 		AvoidTolls:    c.AvoidTolls,
 		AvoidHighways: c.AvoidHighways,
 		AvoidFerries:  c.AvoidFerries,
+		DepartureTime: c.DepartureTime,
+		ArrivalTime:   c.ArrivalTime,
 		Language:      c.Language,
 		Region:        c.Region,
 	}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -169,6 +169,8 @@ func renderDirections(color Color, response goplaces.DirectionsResponse, include
 	writeLine(&out, color, "Summary", response.Summary)
 	writeLine(&out, color, "Distance", response.DistanceText)
 	writeLine(&out, color, "Duration", response.DurationText)
+	writeLine(&out, color, "Departure", response.DepartureTime)
+	writeLine(&out, color, "Arrival", response.ArrivalTime)
 	if len(response.Warnings) > 0 {
 		out.WriteString(color.Dim("Warnings:"))
 		out.WriteString("\n")

--- a/internal/places/directions.go
+++ b/internal/places/directions.go
@@ -53,6 +53,8 @@ type DirectionsRequest struct {
 	AvoidTolls    bool    `json:"avoid_tolls,omitempty"`
 	AvoidHighways bool    `json:"avoid_highways,omitempty"`
 	AvoidFerries  bool    `json:"avoid_ferries,omitempty"`
+	DepartureTime string  `json:"departure_time,omitempty"`
+	ArrivalTime   string  `json:"arrival_time,omitempty"`
 }
 
 // DirectionsResponse contains a single route summary and steps.
@@ -65,6 +67,8 @@ type DirectionsResponse struct {
 	DistanceMeters  int              `json:"distance_meters,omitempty"`
 	DurationText    string           `json:"duration_text,omitempty"`
 	DurationSeconds int              `json:"duration_seconds,omitempty"`
+	DepartureTime   string           `json:"departure_time,omitempty"`
+	ArrivalTime     string           `json:"arrival_time,omitempty"`
 	Warnings        []string         `json:"warnings,omitempty"`
 	Steps           []DirectionsStep `json:"steps,omitempty"`
 }
@@ -126,6 +130,8 @@ func (c *Client) Directions(ctx context.Context, req DirectionsRequest) (Directi
 		DistanceMeters:  leg.DistanceMeters,
 		DurationText:    strings.TrimSpace(leg.LocalizedValues.Duration.Text),
 		DurationSeconds: parseDurationSeconds(leg.Duration),
+		DepartureTime:   req.DepartureTime,
+		ArrivalTime:     req.ArrivalTime,
 		Warnings:        route.Warnings,
 		Steps:           steps,
 	}, nil
@@ -149,6 +155,8 @@ func applyDirectionsDefaults(req DirectionsRequest) DirectionsRequest {
 	if req.Units == "" {
 		req.Units = directionsUnitsMetric
 	}
+	req.DepartureTime = strings.TrimSpace(req.DepartureTime)
+	req.ArrivalTime = strings.TrimSpace(req.ArrivalTime)
 	return req
 }
 
@@ -169,6 +177,19 @@ func validateDirectionsRequest(req DirectionsRequest) error {
 	}
 	if (req.AvoidTolls || req.AvoidHighways || req.AvoidFerries) && req.Mode != directionsModeDrive {
 		return ValidationError{Field: "route_modifiers", Message: "avoid tolls/highways/ferries require drive mode"}
+	}
+	if req.DepartureTime != "" && req.ArrivalTime != "" {
+		return ValidationError{Field: "time", Message: "use only one of departure_time or arrival_time"}
+	}
+	if req.DepartureTime != "" {
+		if _, err := time.Parse(time.RFC3339, req.DepartureTime); err != nil {
+			return ValidationError{Field: "departure_time", Message: "must be RFC3339, e.g. 2026-05-10T18:57:00-03:00"}
+		}
+	}
+	if req.ArrivalTime != "" {
+		if _, err := time.Parse(time.RFC3339, req.ArrivalTime); err != nil {
+			return ValidationError{Field: "arrival_time", Message: "must be RFC3339, e.g. 2026-05-10T18:57:00-03:00"}
+		}
 	}
 	return nil
 }
@@ -302,6 +323,15 @@ func buildDirectionsBody(req DirectionsRequest) map[string]any {
 			"avoidHighways": req.AvoidHighways,
 			"avoidFerries":  req.AvoidFerries,
 		}
+	}
+	if req.DepartureTime != "" {
+		body["departureTime"] = req.DepartureTime
+		if normalizeDirectionsMode(req.Mode) == directionsModeDrive {
+			body["routingPreference"] = "TRAFFIC_AWARE"
+		}
+	}
+	if req.ArrivalTime != "" {
+		body["arrivalTime"] = req.ArrivalTime
 	}
 	return body
 }


### PR DESCRIPTION
## Summary
- Add --departure-time and --arrival-time flags to the directions command
- Pass departureTime/arrivalTime through to Google Routes API computeRoutes
- Use TRAFFIC_AWARE routing preference for drive routes with departure time
- Include selected time option in JSON and human output
- Document time-aware routing examples

## Test Plan
- go test ./...
- go build -o /tmp/goplaces ./cmd/goplaces
- Live smoke test against Routes API with --departure-time and --arrival-time