### PR TITLE
ci: refresh stable workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -21,14 +21,14 @@ jobs:
       - name: Test (coverage >= 90%)
         run: ./scripts/check-coverage.sh
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
       - name: Lint
         run: make lint
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -41,16 +41,16 @@ jobs:
       - name: Deadcode
         run: |
           output_file=$(mktemp)
-          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test ./... > "$output_file"
           if [ -s "$output_file" ]; then
             cat "$output_file"
             exit 1
           fi
       - name: Security scan
-        run: go run github.com/securego/gosec/v2/cmd/gosec@v2.26.1 ./...
+        run: go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 ./...
       - name: Vulnerability scan
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
-      - uses: goreleaser/goreleaser-action@v6
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: v2.15.4

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, goplaces, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,12 +25,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
         with:
           enablement: true
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -65,7 +65,7 @@ jobs:
             echo "::error::HOMEBREW_TAP_TOKEN cannot access openclaw/homebrew-tap (HTTP $code)"
             exit 1
           fi
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: lint test coverage
 .PHONY: e2e goplaces force
 
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.11.4
 GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 lint:


### PR DESCRIPTION
## Summary

- Refresh GitHub Actions to their current stable major lines.
- Update golangci-lint, deadcode, gosec, and govulncheck to the newest compatible stable pins.
- Keep golangci-lint at v2.11.4: v2.12.2 introduces 23 new cross-file goconst findings that belong in a separate source refactor.
- Keep the GoReleaser config check at v2.15.4: v2.16 turns the existing Formula-to-Cask deprecation into a failing check. A v2.16 snapshot release still builds all six targets successfully, so release execution remains functional while that migration is handled separately.

## Proof

- `./scripts/check-coverage.sh` — 91.3%
- `make lint` — 0 issues
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.47.0 -test ./...`
- `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 ./...` — 0 issues
- `go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...` — no vulnerabilities
- `go mod tidy -diff` and `go mod verify`
- `go run github.com/goreleaser/goreleaser/v2@v2.15.4 check --config .goreleaser.yml`
- `go run github.com/goreleaser/goreleaser/v2@v2.16.0 release --snapshot --clean --skip=publish` — six platform archives plus checksums
- Autoreview: clean; no accepted/actionable findings

## Risk

Medium-low: workflow/runtime dependencies only; no product code or library API changes. Exact-head GitHub Actions is the live proof for checkout, toolchain, Pages, and audit compatibility.
