### PR TITLE
fix: preserve hidden Pages files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,5 +32,6 @@ jobs:
       - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
+          include-hidden-files: true
       - id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Opt the Pages artifact into hidden files so `docs/.nojekyll` survives `actions/upload-pages-artifact@v5`.
- Follow up the actionable review on https://github.com/openclaw/goplaces/pull/15#discussion_r3504941988.

## Root cause

`upload-pages-artifact@v5` defaults `include-hidden-files` to `false`. The artifact from the merged Pages run omitted `.nojekyll`, confirmed by downloading and listing artifact `8006483649`.

## Proof

- Upstream v5 `action.yml` confirms the default and exclusion behavior.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- Local archive of `docs` contains `./.nojekyll`.
- Autoreview: clean; no accepted/actionable findings.

## Risk

Low: one documented workflow input. The current `docs` tree contains only one hidden file, `.nojekyll`.
