### PR TITLE
chore(deps): refresh Go and release toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Test (coverage >= 90%)
         run: ./scripts/check-coverage.sh
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
       - name: Lint
         run: make lint
   audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,5 @@ jobs:
       - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: v2.15.4
+          version: v2.16.0
           args: check --config .goreleaser.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
-            echo "::error::HOMEBREW_TAP_TOKEN is missing; cannot publish Homebrew formula"
+            echo "::error::HOMEBREW_TAP_TOKEN is missing; cannot publish Homebrew cask"
             exit 1
           fi
           code="$(curl -sS -o /dev/null -w '%{http_code}' \
@@ -73,18 +73,57 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      - name: Verify Homebrew formula
+      - name: Verify Homebrew cask
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
         run: |
           release_version="${RELEASE_TAG#v}"
-          formula="$(gh api repos/openclaw/homebrew-tap/contents/Formula/goplaces.rb --jq '.content' | base64 --decode)"
-          if ! grep -q "version \"${release_version}\"" <<<"$formula"; then
-            echo "::error::openclaw/homebrew-tap Formula/goplaces.rb was not updated to $release_version"
+          cask="$(gh api repos/openclaw/homebrew-tap/contents/Casks/goplaces.rb --jq '.content' | base64 --decode)"
+          if ! grep -q "version \"${release_version}\"" <<<"$cask"; then
+            echo "::error::openclaw/homebrew-tap Casks/goplaces.rb was not updated to $release_version"
             exit 1
           fi
-          if ! grep -q "releases/download/v${release_version}/" <<<"$formula"; then
-            echo "::error::openclaw/homebrew-tap Formula/goplaces.rb does not point at v$release_version assets"
+          if ! grep -q "releases/download/v${release_version}/" <<<"$cask"; then
+            echo "::error::openclaw/homebrew-tap Casks/goplaces.rb does not point at v$release_version assets"
+            exit 1
+          fi
+      - name: Migrate Homebrew formula users to the cask
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          gh auth setup-git
+          tap_dir="$RUNNER_TEMP/homebrew-tap"
+          git clone https://github.com/openclaw/homebrew-tap.git "$tap_dir"
+          cd "$tap_dir"
+
+          if [ -f tap_migrations.json ]; then
+            jq -e 'type == "object"' tap_migrations.json >/dev/null
+          else
+            echo '{}' > tap_migrations.json
+          fi
+          jq -S '. + {"goplaces": "goplaces"}' tap_migrations.json > tap_migrations.json.tmp
+          mv tap_migrations.json.tmp tap_migrations.json
+          rm -f Formula/goplaces.rb
+
+          if [ -z "$(git status --porcelain -- Formula/goplaces.rb tap_migrations.json)" ]; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add --all -- Formula/goplaces.rb tap_migrations.json
+          git commit -m "chore: migrate goplaces formula to cask"
+          git push origin HEAD:main
+      - name: Verify Homebrew migration
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if gh api repos/openclaw/homebrew-tap/contents/Formula/goplaces.rb >/dev/null 2>&1; then
+            echo "::error::openclaw/homebrew-tap still contains Formula/goplaces.rb"
+            exit 1
+          fi
+          migrations="$(gh api repos/openclaw/homebrew-tap/contents/tap_migrations.json --jq '.content' | base64 --decode)"
+          if ! jq -e '.goplaces == "goplaces"' <<<"$migrations" >/dev/null; then
+            echo "::error::openclaw/homebrew-tap does not migrate goplaces to its cask"
             exit 1
           fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,17 +36,20 @@ changelog:
       - '^docs:'
       - '^test:'
 
-brews:
+homebrew_casks:
   - name: goplaces
+    binaries:
+      - goplaces
     description: "Modern Go client + CLI for the Google Places API (New)."
     homepage: "https://github.com/openclaw/goplaces"
-    license: "MIT"
-    directory: Formula
+    directory: Casks
     repository:
       owner: openclaw
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    install: |
-      bin.install "goplaces"
-    test: |
-      system "#{bin}/goplaces", "--version"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/goplaces"]
+          end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - CLI: accept space-separated negative numeric flag values such as coordinates. (#17) - thanks @technicalpickles
+- Release: update GoReleaser to 2.16.0 and migrate Homebrew publishing from Formula to Cask.
+- Build: require Go 1.26.4 and update golangci-lint to 2.12.2.
 
 ## 0.4.3 - 2026-05-20
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: lint test coverage
 .PHONY: e2e goplaces force
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 lint:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Typical jobs:
 
 Latest release: v0.4.3 (2026-05-20).
 
-- Homebrew: `brew install openclaw/tap/goplaces`
+- Homebrew: `brew install --cask openclaw/tap/goplaces`
 - Go: `go install github.com/steipete/goplaces/cmd/goplaces@latest`
 - Source: `make goplaces`
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
         </div>
         <div class="qi" role="group" aria-label="Quick install">
           <span class="dollar">$</span>
-          <span class="text" id="qi-cmd">brew install openclaw/tap/goplaces</span>
+          <span class="text" id="qi-cmd">brew install --cask openclaw/tap/goplaces</span>
           <button class="copy" data-copy="#qi-cmd" aria-label="Copy install command">Copy</button>
         </div>
         <div class="stats" aria-label="Project at a glance">
@@ -199,11 +199,11 @@ Joe Coffee Company       <span class="tk-num">4.3</span>  <span class="tk-warn">
           </div>
 
           <div role="tabpanel" id="t-brew" class="tab-panel is-active">
-            <div class="codebar"><span class="pill">shell</span><button class="copy" data-copy="#code-brew" data-copy-text="brew install openclaw/tap/goplaces
+            <div class="codebar"><span class="pill">shell</span><button class="copy" data-copy="#code-brew" data-copy-text="brew install --cask openclaw/tap/goplaces
 export GOOGLE_PLACES_API_KEY=&quot;...&quot;
 goplaces search &quot;bookstore&quot;">Copy</button></div>
 <pre id="code-brew"><span class="tk-c"># Install via the OpenClaw tap</span>
-<span class="tk-prompt">$ </span>brew install openclaw/tap/goplaces
+<span class="tk-prompt">$ </span>brew install --cask openclaw/tap/goplaces
 <span class="tk-prompt">$ </span>export GOOGLE_PLACES_API_KEY=<span class="tk-str">"..."</span>
 <span class="tk-prompt">$ </span>goplaces search <span class="tk-str">"bookstore"</span></pre>
           </div>

--- a/docs/releasing-homebrew.md
+++ b/docs/releasing-homebrew.md
@@ -1,6 +1,6 @@
 # goplaces Homebrew Release Playbook
 
-Homebrew formula update notes for the automated release.
+Homebrew cask update notes for the automated release.
 
 ## Prereqs
 
@@ -11,15 +11,16 @@ Homebrew formula update notes for the automated release.
 
 1) Tag + push: `git tag vX.Y.Z && git push origin vX.Y.Z`
 2) GitHub Actions runs GoReleaser.
-3) GoReleaser updates `openclaw/homebrew-tap` at `Formula/goplaces.rb`.
+3) GoReleaser updates `openclaw/homebrew-tap` at `Casks/goplaces.rb`.
+4) The release workflow adds the `tap_migrations.json` entry and removes the retired Formula in the same commit.
 
 ## Verify install
 
 ```bash
-brew update && brew install openclaw/tap/goplaces
+brew update && brew install --cask openclaw/tap/goplaces
 ```
 
 ## Troubleshooting
 
-- If the formula is missing or stale, inspect the release workflow token check and GoReleaser `brews` config.
-- If a root-level `goplaces.rb` appears in the tap, remove it; `Formula/goplaces.rb` is canonical.
+- If the cask is missing or stale, inspect the release workflow token check and GoReleaser `homebrew_casks` config.
+- `Casks/goplaces.rb` is canonical. The old `Formula/goplaces.rb` must stay absent after migration.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,13 +17,13 @@ git push origin vX.Y.Z
 ```
 
 GitHub Actions runs GoReleaser on tag push (`.github/workflows/release.yml`).
-GoReleaser publishes the GitHub release archives, checksums, and Homebrew formula.
+GoReleaser publishes the GitHub release archives, checksums, and Homebrew cask.
 
 ## Verify Release
 
 - GitHub release exists for `vX.Y.Z` with archives and checksums.
-- `openclaw/homebrew-tap` has `Formula/goplaces.rb` for `X.Y.Z`.
-- `brew update && brew install openclaw/tap/goplaces` works.
+- `openclaw/homebrew-tap` has `Casks/goplaces.rb` for `X.Y.Z` and maps former Formula users through `tap_migrations.json`.
+- `brew update && brew install --cask openclaw/tap/goplaces` works.
 
 ## Notes
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/steipete/goplaces
 
-go 1.25.11
+go 1.26.4
 
 require github.com/alecthomas/kong v1.15.0

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -21,7 +21,7 @@ const (
 	directionsModeWalkAPI    = "WALK"
 	directionsModeDriveAPI   = "DRIVE"
 	directionsModeTransitAPI = "TRANSIT"
-	directionsModeWalking    = "walking"
+	directionsModeWalkingAPI = "walking"
 )
 
 func TestRunSearchJSON(t *testing.T) {
@@ -893,7 +893,7 @@ func TestRunDirectionsValidationErrors(t *testing.T) {
 		},
 		{
 			name: "same compare mode",
-			args: []string{"directions", "--from", "A", "--to", "B", "--mode", "walk", "--compare", directionsModeWalking, "--api-key", "x"},
+			args: []string{"directions", "--from", "A", "--to", "B", "--mode", "walk", "--compare", directionsModeWalkingAPI, "--api-key", "x"},
 		},
 		{
 			name: "partial from latlng",
@@ -931,8 +931,8 @@ func TestRunDirectionsValidationErrors(t *testing.T) {
 
 func TestNormalizeDirectionsMode(t *testing.T) {
 	cases := map[string]string{
-		"walk":      directionsModeWalking,
-		"walking":   directionsModeWalking,
+		"walk":      directionsModeWalkingAPI,
+		"walking":   directionsModeWalkingAPI,
 		"drive":     directionsModeDriving,
 		"driving":   directionsModeDriving,
 		"bike":      "bicycling",

--- a/internal/cli/directions.go
+++ b/internal/cli/directions.go
@@ -7,7 +7,16 @@ import (
 	"github.com/steipete/goplaces"
 )
 
-const directionsModeDriving = "driving"
+const (
+	directionsModeWalk               = "walk"
+	directionsModeWalking            = "walking"
+	directionsModeDrive              = "drive"
+	directionsModeDriving            = "driving"
+	directionsModeBicycling          = "bicycling"
+	directionsModeTransit            = "transit"
+	directionsValidationFieldCompare = "compare"
+	directionsValidationMessageModes = "must be walk, drive, bicycle, or transit"
+)
 
 // DirectionsCmd fetches directions between two points.
 type DirectionsCmd struct {
@@ -42,13 +51,13 @@ func (c *DirectionsCmd) Run(app *App) error {
 	if strings.TrimSpace(c.Compare) != "" {
 		compareMode = normalizeDirectionsMode(c.Compare)
 		if compareMode == "" {
-			return goplaces.ValidationError{Field: "compare", Message: "must be walk, drive, bicycle, or transit"}
+			return goplaces.ValidationError{Field: directionsValidationFieldCompare, Message: directionsValidationMessageModes}
 		}
 		if compareMode == primaryMode {
-			return goplaces.ValidationError{Field: "compare", Message: "must be different from mode"}
+			return goplaces.ValidationError{Field: directionsValidationFieldCompare, Message: "must be different from mode"}
 		}
 		if strings.TrimSpace(c.ArrivalTime) != "" {
-			return goplaces.ValidationError{Field: "compare", Message: "cannot combine with arrival_time"}
+			return goplaces.ValidationError{Field: directionsValidationFieldCompare, Message: "cannot combine with arrival_time"}
 		}
 	}
 
@@ -134,14 +143,14 @@ func (c *DirectionsCmd) Run(app *App) error {
 
 func normalizeDirectionsMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case "walk", "walking":
-		return "walking"
-	case "drive", "driving":
+	case directionsModeWalk, directionsModeWalking:
+		return directionsModeWalking
+	case directionsModeDrive, directionsModeDriving:
 		return directionsModeDriving
-	case "bike", "bicycle", "bicycling":
-		return "bicycling"
-	case "transit":
-		return "transit"
+	case "bike", "bicycle", directionsModeBicycling:
+		return directionsModeBicycling
+	case directionsModeTransit:
+		return directionsModeTransit
 	default:
 		return ""
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -13,6 +13,8 @@ import (
 	"github.com/steipete/goplaces"
 )
 
+const locationCoordinatesRequired = "lat, lng, radius required"
+
 // App wires CLI output and API access.
 type App struct {
 	client *goplaces.Client
@@ -156,7 +158,7 @@ func (c *SearchCmd) Run(app *App) error {
 
 	if c.Lat != nil || c.Lng != nil || c.RadiusM != nil {
 		if c.Lat == nil || c.Lng == nil || c.RadiusM == nil {
-			return goplaces.ValidationError{Field: "location_bias", Message: "lat, lng, radius required"}
+			return goplaces.ValidationError{Field: "location_bias", Message: locationCoordinatesRequired}
 		}
 		request.LocationBias = &goplaces.LocationBias{
 			Lat:     *c.Lat,
@@ -190,7 +192,7 @@ func (c *AutocompleteCmd) Run(app *App) error {
 
 	if c.Lat != nil || c.Lng != nil || c.RadiusM != nil {
 		if c.Lat == nil || c.Lng == nil || c.RadiusM == nil {
-			return goplaces.ValidationError{Field: "location_bias", Message: "lat, lng, radius required"}
+			return goplaces.ValidationError{Field: "location_bias", Message: locationCoordinatesRequired}
 		}
 		request.LocationBias = &goplaces.LocationBias{
 			Lat:     *c.Lat,
@@ -215,7 +217,7 @@ func (c *AutocompleteCmd) Run(app *App) error {
 // Run executes the nearby command.
 func (c *NearbyCmd) Run(app *App) error {
 	if c.Lat == nil || c.Lng == nil || c.RadiusM == nil {
-		return goplaces.ValidationError{Field: "location_restriction", Message: "lat, lng, radius required"}
+		return goplaces.ValidationError{Field: "location_restriction", Message: locationCoordinatesRequired}
 	}
 
 	request := goplaces.NearbySearchRequest{

--- a/internal/places/autocomplete.go
+++ b/internal/places/autocomplete.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-const autocompleteFieldMask = "suggestions.placePrediction.placeId,suggestions.placePrediction.place,suggestions.placePrediction.text,suggestions.placePrediction.structuredFormat,suggestions.placePrediction.types,suggestions.placePrediction.distanceMeters,suggestions.queryPrediction.text,suggestions.queryPrediction.structuredFormat"
+const (
+	autocompleteFieldMask           = "suggestions.placePrediction.placeId,suggestions.placePrediction.place,suggestions.placePrediction.text,suggestions.placePrediction.structuredFormat,suggestions.placePrediction.types,suggestions.placePrediction.distanceMeters,suggestions.queryPrediction.text,suggestions.queryPrediction.structuredFormat"
+	autocompleteSuggestionKindQuery = validationFieldQuery
+)
 
 // Autocomplete returns place and query suggestions for an input string.
 func (c *Client) Autocomplete(ctx context.Context, req AutocompleteRequest) (AutocompleteResponse, error) {
@@ -115,7 +118,7 @@ func mapAutocompleteSuggestion(payload autocompleteSuggestionPayload) (Autocompl
 		prediction := payload.QueryPrediction
 		structured := prediction.StructuredFormat
 		return AutocompleteSuggestion{
-			Kind:          "query",
+			Kind:          autocompleteSuggestionKindQuery,
 			Text:          autocompleteText(prediction.Text),
 			MainText:      autocompleteText(structuredText(structured, true)),
 			SecondaryText: autocompleteText(structuredText(structured, false)),
@@ -150,10 +153,10 @@ func applyAutocompleteDefaults(req AutocompleteRequest) AutocompleteRequest {
 
 func validateAutocompleteRequest(req AutocompleteRequest) error {
 	if strings.TrimSpace(req.Input) == "" {
-		return ValidationError{Field: "input", Message: "required"}
+		return ValidationError{Field: "input", Message: validationMessageRequired}
 	}
 	if req.Limit < 1 || req.Limit > maxAutocompleteLimit {
-		return ValidationError{Field: "limit", Message: fmt.Sprintf("must be 1-%d", maxAutocompleteLimit)}
+		return ValidationError{Field: validationFieldLimit, Message: fmt.Sprintf("must be 1-%d", maxAutocompleteLimit)}
 	}
 	if req.LocationBias != nil {
 		if err := validateLocationBias(req.LocationBias); err != nil {

--- a/internal/places/details.go
+++ b/internal/places/details.go
@@ -23,7 +23,7 @@ func (c *Client) Details(ctx context.Context, placeID string) (PlaceDetails, err
 func (c *Client) DetailsWithOptions(ctx context.Context, req DetailsRequest) (PlaceDetails, error) {
 	placeID := strings.TrimSpace(req.PlaceID)
 	if placeID == "" {
-		return PlaceDetails{}, ValidationError{Field: "place_id", Message: "required"}
+		return PlaceDetails{}, ValidationError{Field: validationFieldPlaceID, Message: validationMessageRequired}
 	}
 
 	path, err := placeDetailsPath(placeID)
@@ -56,10 +56,10 @@ func placeDetailsPath(placeID string) (string, error) {
 	placeID = strings.TrimPrefix(strings.TrimSpace(placeID), "/")
 	placeID = strings.TrimPrefix(placeID, "places/")
 	if placeID == "" {
-		return "", ValidationError{Field: "place_id", Message: "required"}
+		return "", ValidationError{Field: validationFieldPlaceID, Message: validationMessageRequired}
 	}
 	if strings.Contains(placeID, "/") {
-		return "", ValidationError{Field: "place_id", Message: "must be a place ID or places/{place_id}"}
+		return "", ValidationError{Field: validationFieldPlaceID, Message: "must be a place ID or places/{place_id}"}
 	}
 	return "/places/" + pathEscapeSegment(placeID), nil
 }

--- a/internal/places/directions.go
+++ b/internal/places/directions.go
@@ -17,10 +17,12 @@ const (
 const directionsFieldMask = "routes.description,routes.warnings,routes.legs.distanceMeters,routes.legs.duration,routes.legs.localizedValues.distance,routes.legs.localizedValues.duration,routes.legs.steps.distanceMeters,routes.legs.steps.staticDuration,routes.legs.steps.localizedValues.distance,routes.legs.steps.localizedValues.staticDuration,routes.legs.steps.navigationInstruction.instructions,routes.legs.steps.navigationInstruction.maneuver,routes.legs.steps.travelMode"
 
 const (
-	directionsModeWalk    = "walking"
-	directionsModeDrive   = "driving"
-	directionsModeBicycle = "bicycling"
-	directionsModeTransit = "transit"
+	directionsModeWalk       = "walking"
+	directionsModeDrive      = "driving"
+	directionsModeBicycle    = "bicycling"
+	directionsModeTransit    = "transit"
+	directionsModeAliasWalk  = "walk"
+	directionsModeAliasDrive = "drive"
 )
 
 const (
@@ -164,7 +166,7 @@ func validateDirectionsRequest(req DirectionsRequest) error {
 	if normalizeDirectionsMode(req.Mode) == "" {
 		return ValidationError{Field: "mode", Message: "must be walk, drive, bicycle, or transit"}
 	}
-	if err := validateDirectionsLocation("from", req.FromPlaceID, req.FromLocation, req.From); err != nil {
+	if err := validateDirectionsLocation(validationFieldFrom, req.FromPlaceID, req.FromLocation, req.From); err != nil {
 		return err
 	}
 	if err := validateDirectionsLocation("to", req.ToPlaceID, req.ToLocation, req.To); err != nil {
@@ -215,7 +217,7 @@ func validateDirectionsLocation(label, placeID string, location *LatLng, text st
 		provided++
 	}
 	if provided == 0 {
-		return ValidationError{Field: label, Message: "required"}
+		return ValidationError{Field: label, Message: validationMessageRequired}
 	}
 	if provided > 1 {
 		return ValidationError{Field: label, Message: "use only one of text, place_id, or lat/lng"}
@@ -246,13 +248,13 @@ func directionsLocationLabel(placeID string, location *LatLng, text string) stri
 
 func normalizeDirectionsMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case "walk", "walking":
+	case directionsModeAliasWalk, directionsModeWalk:
 		return directionsModeWalk
-	case "drive", "driving":
+	case directionsModeAliasDrive, directionsModeDrive:
 		return directionsModeDrive
-	case "bike", "bicycle", "bicycling":
+	case "bike", "bicycle", directionsModeBicycle:
 		return directionsModeBicycle
-	case "transit":
+	case directionsModeTransit:
 		return directionsModeTransit
 	default:
 		return ""
@@ -301,7 +303,7 @@ func directionsWaypoint(placeID string, location *LatLng, text string) map[strin
 			},
 		}
 	}
-	return map[string]any{"address": strings.TrimSpace(text)}
+	return map[string]any{payloadFieldAddress: strings.TrimSpace(text)}
 }
 
 func buildDirectionsBody(req DirectionsRequest) map[string]any {

--- a/internal/places/nearby.go
+++ b/internal/places/nearby.go
@@ -65,13 +65,13 @@ func applyNearbyDefaults(req NearbySearchRequest) NearbySearchRequest {
 
 func validateNearbyRequest(req NearbySearchRequest) error {
 	if req.LocationRestriction == nil {
-		return ValidationError{Field: "location_restriction", Message: "required"}
+		return ValidationError{Field: "location_restriction", Message: validationMessageRequired}
 	}
 	if err := validateCircle(req.LocationRestriction, "location_restriction"); err != nil {
 		return err
 	}
 	if req.Limit < 1 || req.Limit > maxNearbyLimit {
-		return ValidationError{Field: "limit", Message: fmt.Sprintf("must be 1-%d", maxNearbyLimit)}
+		return ValidationError{Field: validationFieldLimit, Message: fmt.Sprintf("must be 1-%d", maxNearbyLimit)}
 	}
 	return nil
 }

--- a/internal/places/photo.go
+++ b/internal/places/photo.go
@@ -15,7 +15,7 @@ const maxPhotoDimensionPx = 4800
 func (c *Client) PhotoMedia(ctx context.Context, req PhotoMediaRequest) (PhotoMediaResponse, error) {
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
-		return PhotoMediaResponse{}, ValidationError{Field: "name", Message: "required"}
+		return PhotoMediaResponse{}, ValidationError{Field: "name", Message: validationMessageRequired}
 	}
 	if req.MaxWidthPx < 0 || req.MaxWidthPx > maxPhotoDimensionPx {
 		return PhotoMediaResponse{}, ValidationError{Field: "max_width_px", Message: fmt.Sprintf("must be 1-%d", maxPhotoDimensionPx)}

--- a/internal/places/resolve.go
+++ b/internal/places/resolve.go
@@ -69,10 +69,10 @@ func applyResolveDefaults(req LocationResolveRequest) LocationResolveRequest {
 
 func validateResolveRequest(req LocationResolveRequest) error {
 	if strings.TrimSpace(req.LocationText) == "" {
-		return ValidationError{Field: "location_text", Message: "required"}
+		return ValidationError{Field: "location_text", Message: validationMessageRequired}
 	}
 	if req.Limit < 1 || req.Limit > maxResolveLimit {
-		return ValidationError{Field: "limit", Message: fmt.Sprintf("must be 1-%d", maxResolveLimit)}
+		return ValidationError{Field: validationFieldLimit, Message: fmt.Sprintf("must be 1-%d", maxResolveLimit)}
 	}
 	return nil
 }

--- a/internal/places/route.go
+++ b/internal/places/route.go
@@ -199,22 +199,22 @@ func applyRouteDefaults(req RouteRequest) RouteRequest {
 
 func validateRouteRequest(req RouteRequest) error {
 	if req.Query == "" {
-		return ValidationError{Field: "query", Message: "required"}
+		return ValidationError{Field: validationFieldQuery, Message: validationMessageRequired}
 	}
 	if req.From == "" {
-		return ValidationError{Field: "from", Message: "required"}
+		return ValidationError{Field: validationFieldFrom, Message: validationMessageRequired}
 	}
 	if req.To == "" {
-		return ValidationError{Field: "to", Message: "required"}
+		return ValidationError{Field: "to", Message: validationMessageRequired}
 	}
 	if req.Limit < 1 || req.Limit > maxSearchLimit {
-		return ValidationError{Field: "limit", Message: fmt.Sprintf("must be 1-%d", maxSearchLimit)}
+		return ValidationError{Field: validationFieldLimit, Message: fmt.Sprintf("must be 1-%d", maxSearchLimit)}
 	}
 	if req.RadiusM <= 0 {
-		return ValidationError{Field: "radius_m", Message: "must be > 0"}
+		return ValidationError{Field: validationFieldRadiusM, Message: "must be > 0"}
 	}
 	if req.RadiusM > maxCircleRadiusM {
-		return ValidationError{Field: "radius_m", Message: fmt.Sprintf("must be <= %d", maxCircleRadiusM)}
+		return ValidationError{Field: validationFieldRadiusM, Message: fmt.Sprintf("must be <= %d", maxCircleRadiusM)}
 	}
 	if req.MaxWaypoints < 1 || req.MaxWaypoints > maxRouteWaypoints {
 		return ValidationError{Field: "max_waypoints", Message: fmt.Sprintf("must be 1-%d", maxRouteWaypoints)}
@@ -228,10 +228,10 @@ func validateRouteRequest(req RouteRequest) error {
 func (c *Client) computeRoutePolyline(ctx context.Context, req RouteRequest) (string, error) {
 	body := map[string]any{
 		"origin": map[string]any{
-			"address": req.From,
+			payloadFieldAddress: req.From,
 		},
 		"destination": map[string]any{
-			"address": req.To,
+			payloadFieldAddress: req.To,
 		},
 		"travelMode":       req.Mode,
 		"polylineQuality":  "OVERVIEW",

--- a/internal/places/search.go
+++ b/internal/places/search.go
@@ -122,10 +122,10 @@ func applySearchDefaults(req SearchRequest) SearchRequest {
 
 func validateSearchRequest(req SearchRequest) error {
 	if strings.TrimSpace(req.Query) == "" {
-		return ValidationError{Field: "query", Message: "required"}
+		return ValidationError{Field: validationFieldQuery, Message: validationMessageRequired}
 	}
 	if req.Limit < 1 || req.Limit > maxSearchLimit {
-		return ValidationError{Field: "limit", Message: fmt.Sprintf("must be 1-%d", maxSearchLimit)}
+		return ValidationError{Field: validationFieldLimit, Message: fmt.Sprintf("must be 1-%d", maxSearchLimit)}
 	}
 
 	if req.Filters != nil {

--- a/internal/places/validation.go
+++ b/internal/places/validation.go
@@ -2,6 +2,16 @@ package places
 
 import "fmt"
 
+const (
+	payloadFieldAddress       = "address"
+	validationFieldFrom       = "from"
+	validationFieldLimit      = "limit"
+	validationFieldPlaceID    = "place_id"
+	validationFieldQuery      = "query"
+	validationFieldRadiusM    = "radius_m"
+	validationMessageRequired = "required"
+)
+
 const maxCircleRadiusM = 50000
 
 func validateLocationBias(bias *LocationBias) error {


### PR DESCRIPTION
## Summary

- require Go 1.26.4 and golangci-lint 2.12.2, including the small constant-extraction repairs required by the current lint rules
- update GoReleaser to 2.16.0 and publish goplaces as a Homebrew Cask instead of a deprecated binary Formula
- migrate existing Formula installs through Homebrew's documented same-token `tap_migrations.json` path and verify the resulting tap state in the release workflow
- refresh install and release documentation for the Cask path

## Proof

- `./scripts/check-coverage.sh` — 91.4%
- `go test -race ./...`
- `go vet ./...`
- `make lint` — 0 issues
- actionlint, Staticcheck 0.7.0, deadcode 0.47.0, gosec 2.27.1 — 0 findings
- govulncheck 1.5.0 — no vulnerabilities
- `goreleaser check --config .goreleaser.yml`
- `goreleaser release --snapshot --clean --skip=publish` — six targets, checksums, and Cask generated
- built Darwin arm64 CLI reports the snapshot version
- generated Cask passes Ruby syntax and Homebrew's strict offline Cask auditor
- public model-identifier gate — no model-bearing surface

## Review

AutoReview found no accepted/actionable issue. Its same-token migration warning was rejected against GoReleaser's current documented Formula-to-Cask migration and Homebrew's current update reporter, which explicitly detects and installs a same-tap Cask when the Formula is removed.
