### PR TITLE
chore(release): prepare v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.4.4 - 2026-07-04
 
 - CLI: accept space-separated negative numeric flag values such as coordinates. (#17) - thanks @technicalpickles
 - Release: update GoReleaser to 2.16.0 and migrate Homebrew publishing from Formula to Cask.
 - Build: require Go 1.26.4 and update golangci-lint to 2.12.2.
+- Docs: define project direction and compatibility policy.
 
 ## 0.4.3 - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Typical jobs:
 
 ## Install / Run
 
-Latest release: v0.4.3 (2026-05-20).
+Latest release: v0.4.4 (2026-07-04).
 
 - Homebrew: `brew install --cask openclaw/tap/goplaces`
 - Go: `go install github.com/steipete/goplaces/cmd/goplaces@latest`


### PR DESCRIPTION
## Release v0.4.4

Patch release for the negative numeric flag parser fix, refreshed Go/lint/release toolchain, Homebrew Formula-to-Cask migration, and durable project compatibility policy.

## Proof

- queue before release: zero open pull requests, zero open issues
- `./scripts/check-coverage.sh` — 91.4%
- `go test -race ./...`
- `go vet ./...`
- `make lint` — 0 issues
- actionlint
- `goreleaser check --config .goreleaser.yml`
- v0.4.4 tag and GitHub Release confirmed absent before preparation
- release metadata diff reviewed under freeze discipline; no product behavior added

Tagging and publishing remain gated on this exact PR head landing green on `main`.
