### PR TITLE
fix(release): accept interpolated Cask URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
             echo "::error::openclaw/homebrew-tap Casks/goplaces.rb was not updated to $release_version"
             exit 1
           fi
-          if ! grep -q "releases/download/v${release_version}/" <<<"$cask"; then
+          if ! grep -q 'releases/download/v#{version}/' <<<"$cask" &&
+             ! grep -q "releases/download/v${release_version}/" <<<"$cask"; then
             echo "::error::openclaw/homebrew-tap Casks/goplaces.rb does not point at v$release_version assets"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- accept GoReleaser's generated `v#{version}` interpolation when verifying the published Cask URL
- retain support for concrete version URLs
- keep the downstream release gate fail-closed for any other URL shape

## Proof

- `actionlint`
- the exact Cask published for v0.4.4 passes the repaired verification
- the original tag workflow failed only after publishing all seven release assets and the correct v0.4.4 Cask

Release blocker for https://github.com/openclaw/goplaces/actions/runs/28695337491.
