### PR TITLE
chore(release): open v0.4.5 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Release: accept interpolated Cask URLs and make completed release reruns idempotent.
+
 ## 0.4.4 - 2026-07-04
 
 - CLI: accept space-separated negative numeric flag values such as coordinates. (#17) - thanks @technicalpickles


### PR DESCRIPTION
## Summary

- reopen the changelog for v0.4.5 development after the verified v0.4.4 release
- record the post-tag release-verification and idempotent-rerun repairs under Unreleased

## Proof

- v0.4.4 GitHub Release, seven assets, checksums, Homebrew Cask, Formula migration, archive binary, Cask migration, and Go install verified
- `git diff --check`
