### PR TITLE
fix(places): apply Timeout when HTTPClient has none

### DIFF
--- a/internal/places/client.go
+++ b/internal/places/client.go
@@ -51,13 +51,17 @@ func NewClient(opts Options) *Client {
 		directionsBaseURL = defaultDirectionsBaseURL
 	}
 
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
 	client := opts.HTTPClient
 	if client == nil {
-		timeout := opts.Timeout
-		if timeout == 0 {
-			timeout = 10 * time.Second
-		}
 		client = &http.Client{Timeout: timeout}
+	} else if client.Timeout == 0 {
+		cloned := *client
+		cloned.Timeout = timeout
+		client = &cloned
 	}
 
 	return &Client{

--- a/internal/places/client_options_test.go
+++ b/internal/places/client_options_test.go
@@ -3,7 +3,9 @@ package places
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestMissingAPIKey(t *testing.T) {
@@ -89,6 +91,30 @@ func TestValidationErrors(t *testing.T) {
 	_, err = client.Details(context.Background(), "")
 	if err == nil {
 		t.Fatalf("expected details error")
+	}
+}
+
+func TestNewClientAppliesTimeoutToProvidedClient(t *testing.T) {
+	provided := &http.Client{}
+	client := NewClient(Options{
+		APIKey:     "test-key",
+		HTTPClient: provided,
+		Timeout:    2 * time.Second,
+	})
+	if client.httpClient.Timeout != 2*time.Second {
+		t.Fatalf("timeout=%s want 2s", client.httpClient.Timeout)
+	}
+	if provided.Timeout != 0 {
+		t.Fatalf("mutated caller client timeout=%s", provided.Timeout)
+	}
+	explicit := &http.Client{Timeout: 7 * time.Second}
+	kept := NewClient(Options{
+		APIKey:     "test-key",
+		HTTPClient: explicit,
+		Timeout:    2 * time.Second,
+	})
+	if kept.httpClient.Timeout != 7*time.Second {
+		t.Fatalf("explicit timeout=%s want 7s", kept.httpClient.Timeout)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where callers that pass their own `http.Client` (including an empty `&http.Client{}`) never get `Options.Timeout`. A stalled Google Places TCP connection then hangs the request forever.

The CLI already sets `Timeout` (default 10s). That value was ignored whenever `HTTPClient` was non-nil.

## Why This Change Was Made

`NewClient` now applies `Options.Timeout` (default 10s) when the provided client has `Timeout == 0`. The provided client is cloned so the caller is not mutated. An explicit non-zero `HTTPClient.Timeout` is kept.

## User Impact

Library and CLI callers that pass a custom client without a timeout now get the same 10s bound as the default client. Callers that already set a timeout are unchanged.

## Evidence

Before (unfixed `NewClient` with `&http.Client{}` and `Timeout: 2s`):

```console
$ go test ./internal/places -count=1 -run TestNewClientAppliesTimeoutToProvidedClient
--- FAIL: TestNewClientAppliesTimeoutToProvidedClient (0.00s)
    client_options_test.go:105: timeout=0s want 2s
FAIL
```

After this patch:

```console
$ go test ./internal/places -count=1 -run TestNewClientAppliesTimeoutToProvidedClient
ok  	github.com/steipete/goplaces/internal/places	0.238s
```

The caller’s original client stays at `Timeout 0`. An explicit 7s client timeout is preserved.

## Real behavior proof

- **Behavior or issue addressed:** Provided HTTP clients with no Timeout ignored Options.Timeout and could hang forever on a stalled Places request.
- **Real environment tested:** macOS, Go toolchain, module checkout at `/tmp/gp-http-timeout`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/gp-http-timeout
  go test ./internal/places -count=1 -run TestNewClientAppliesTimeoutToProvidedClient
  ```

- **Evidence after fix:** terminal output from the patched tree:

  ```console
  $ go test ./internal/places -count=1 -run TestNewClientAppliesTimeoutToProvidedClient
  ok  	github.com/steipete/goplaces/internal/places	0.238s
  ```

- **Observed result after fix:** A provided client with Timeout 0 now receives Options.Timeout (2s in the probe, 10s default). Explicit non-zero timeouts stay as the caller set them.
- **What was not tested:** Live Google Places API against a real stalled TCP peer.
