### PR TITLE
fix(docs): validate llms metadata as plain text

### DIFF
--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -18,8 +18,11 @@ const pages = allHtml(docsDir)
     const html = fs.readFileSync(file, "utf8");
     return {
       rel,
-      title: textContent(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]) || titleize(path.basename(rel, ".html")),
-      description: attr(html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["'][^>]*>/i)?.[1] || ""),
+      title: metadataText(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1], "title") || titleize(path.basename(rel, ".html")),
+      description: metadataText(
+        html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["'][^>]*>/i)?.[1],
+        "description",
+      ),
     };
   })
   .filter(Boolean)
@@ -57,17 +60,12 @@ function pageUrl(rel) {
   return rel === "index.html" ? origin + "/" : origin + "/" + rel;
 }
 
-function textContent(value) {
-  return attr(value || "").replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
-}
-
-function attr(value) {
-  return String(value || "")
-    .replace(/&mdash;/g, "-")
-    .replace(/&amp;/g, "&")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&#39;/g, "'")
-    .replace(/&quot;/g, '"')
+export function metadataText(value, field) {
+  const text = String(value || "");
+  if (/[<>]/.test(text)) throw new Error(`${field} must be plain text`);
+  return text
+    .replace(/&(?:mdash|amp|nbsp|#39|quot);/g, (entity) => ({ "&mdash;": "-", "&amp;": "&", "&nbsp;": " ", "&#39;": "'", "&quot;": '"' })[entity])
+    .replace(/\s+/g, " ")
     .trim();
 }
 

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { metadataText } from "./llms-metadata.mjs";
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const docsDir = path.join(repoRoot, "docs");
 const cname = fs.readFileSync(path.join(docsDir, "CNAME"), "utf8").trim();
@@ -58,15 +60,6 @@ function allHtml(dir) {
 
 function pageUrl(rel) {
   return rel === "index.html" ? origin + "/" : origin + "/" + rel;
-}
-
-export function metadataText(value, field) {
-  const text = String(value || "");
-  if (/[<>]/.test(text)) throw new Error(`${field} must be plain text`);
-  return text
-    .replace(/&(?:mdash|amp|nbsp|#39|quot);/g, (entity) => ({ "&mdash;": "-", "&amp;": "&", "&nbsp;": " ", "&#39;": "'", "&quot;": '"' })[entity])
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 function titleize(input) {

--- a/scripts/llms-metadata.mjs
+++ b/scripts/llms-metadata.mjs
@@ -1,0 +1,8 @@
+export function metadataText(value, field) {
+  const text = String(value || "");
+  if (/[<>]/.test(text)) throw new Error(`${field} must be plain text`);
+  return text
+    .replace(/&(?:mdash|amp|nbsp|#39|quot);/g, (entity) => ({ "&mdash;": "-", "&amp;": "&", "&nbsp;": " ", "&#39;": "'", "&quot;": '"' })[entity])
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/scripts/llms-metadata.test.mjs
+++ b/scripts/llms-metadata.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { metadataText } from "./generate-llms.mjs";
+import { metadataText } from "./llms-metadata.mjs";
 
 test("rejects markup instead of trying to sanitize it", () => {
   assert.throws(

--- a/scripts/llms-metadata.test.mjs
+++ b/scripts/llms-metadata.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { metadataText } from "./generate-llms.mjs";
+
+test("rejects markup instead of trying to sanitize it", () => {
+  assert.throws(
+    () => metadataText("<scrip<script>t>alert(1)</script>", "title"),
+    /title must be plain text/,
+  );
+});
+
+test("decodes supported entities exactly once", () => {
+  assert.equal(metadataText("&amp;quot; &quot; &mdash;", "title"), '&quot; " -');
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `llms.txt` generator treated documentation metadata as arbitrary HTML, then tried to remove tags and decode entities with chained replacements. Nested markup could survive the sanitizer, and entity text such as `&amp;quot;` could be decoded twice.

Related alerts:
- https://github.com/openclaw/goplaces/security/code-scanning/1
- https://github.com/openclaw/goplaces/security/code-scanning/2

## Why This Change Was Made

The generator now enforces its actual contract: titles and descriptions must be plain text. It rejects markup instead of trying to sanitize it and decodes the supported entities in one replacement pass.

The normalizer lives in a side-effect-free helper module, so focused tests do not execute the generator or rewrite tracked documentation.

## User Impact

No generated documentation changes. Maintainers get a deterministic failure when page metadata contains markup instead of silently producing ambiguous `llms.txt` output.

## Evidence

- `node --test scripts/llms-metadata.test.mjs`
- `node --check scripts/generate-llms.mjs`
- `node --check scripts/llms-metadata.mjs`
- `node --check scripts/llms-metadata.test.mjs`
- `go test ./...`
- Regenerated `docs/llms.txt`; SHA-256 remained `d17b48d62cd1086a7d61249a84daccea34faedbb0122d307d375fe672eab8a7c`
- Metadata tests leave `docs/llms.txt` unchanged
- `git diff --check`
- Production LOC: +15/-16 (net -1); tests: +15/-0
