### PR TITLE
feat(cli): accept --radius as an alias for --radius-m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.5 - 2026-08-02
 
+- CLI: accept `--radius` as an alias for `--radius-m` on `search`, `nearby`, `autocomplete`, and `route`.
 - Docs: rewrite the README around verified install, quick-start, and reference paths.
 - Release: accept interpolated Cask URLs and make completed release reruns idempotent.
 - Release: keep the pinned GitHub transport reusable across shell command substitutions.

--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -34,3 +34,5 @@ response, err := client.Autocomplete(ctx, goplaces.AutocompleteRequest{
 
 - Use a session token for billing consistency across autocomplete + details.
 - Limit is applied client-side after the API response.
+
+`--radius-m` also accepts the shorter `--radius` spelling.

--- a/docs/nearby-search.md
+++ b/docs/nearby-search.md
@@ -35,3 +35,5 @@ response, err := client.NearbySearch(ctx, goplaces.NearbySearchRequest{
 - Location restriction (lat/lng/radius) is required.
 - Use `IncludedTypes`/`--type` to filter result types.
 - Results include `business_status` when Google returns it.
+
+`--radius-m` also accepts the shorter `--radius` spelling.

--- a/docs/route.md
+++ b/docs/route.md
@@ -11,7 +11,7 @@ goplaces route "coffee" --from "Seattle, WA" --to "Portland, OR" --max-waypoints
 Options:
 
 - `--mode` travel mode: DRIVE, WALK, BICYCLE, TWO_WHEELER, TRANSIT.
-- `--radius-m` search radius per waypoint.
+- `--radius-m` (alias `--radius`) search radius per waypoint.
 - `--limit` results per waypoint.
 
 ## Library

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1377,3 +1377,110 @@ func assertNestedFloat(t *testing.T, payload map[string]any, want float64, path 
 		t.Fatalf("payload path %v = %v, want %v", path, got, want)
 	}
 }
+
+func TestRunRadiusAliasMatchesRadiusM(t *testing.T) {
+	cases := []struct {
+		name       string
+		path       string
+		args       []string
+		radiusPath []string
+	}{
+		{
+			name:       "search",
+			path:       placesSearchPath,
+			args:       []string{"search", "coffee", "--lat", "1", "--lng", "2"},
+			radiusPath: []string{"locationBias", "circle", "radius"},
+		},
+		{
+			name:       "autocomplete",
+			path:       "/places:autocomplete",
+			args:       []string{"autocomplete", "cof", "--lat", "1", "--lng", "2"},
+			radiusPath: []string{"locationBias", "circle", "radius"},
+		},
+		{
+			name:       "nearby",
+			path:       placesNearbyPath,
+			args:       []string{"nearby", "--lat", "1", "--lng", "2"},
+			radiusPath: []string{"locationRestriction", "circle", "radius"},
+		},
+	}
+
+	for _, tc := range cases {
+		for _, flag := range []string{"--radius-m", "--radius", "--radius=1500"} {
+			t.Run(tc.name+" "+flag, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != tc.path {
+						t.Errorf("unexpected path: %s", r.URL.Path)
+					}
+					var payload map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Errorf("decode request: %v", err)
+						return
+					}
+					assertNestedFloat(t, payload, 1500, tc.radiusPath...)
+					_, _ = w.Write([]byte(`{"places": [{"id": "abc"}]}`))
+				}))
+				defer server.Close()
+
+				args := append([]string{}, tc.args...)
+				if strings.Contains(flag, "=") {
+					args = append(args, flag)
+				} else {
+					args = append(args, flag, "1500")
+				}
+				args = append(args, "--api-key", "test-key", "--base-url", server.URL, "--json")
+
+				var stdout, stderr bytes.Buffer
+				if exitCode := Run(args, &stdout, &stderr); exitCode != 0 {
+					t.Fatalf("expected exit code 0, got %d (stderr=%s)", exitCode, stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestRunRouteAcceptsRadiusAlias(t *testing.T) {
+	var searchRadius float64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case routesComputePath:
+			_, _ = w.Write([]byte(`{"routes": [{"polyline": {"encodedPolyline": "_p~iF~ps|U"}}]}`))
+		case placesSearchPath:
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decode request: %v", err)
+				return
+			}
+			if bias, ok := payload["locationBias"].(map[string]any); ok {
+				if circle, ok := bias["circle"].(map[string]any); ok {
+					if radius, ok := circle["radius"].(float64); ok {
+						searchRadius = radius
+					}
+				}
+			}
+			_, _ = w.Write([]byte(`{"places": [{"id": "abc"}]}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{
+		"route", "coffee",
+		"--from", "A",
+		"--to", "B",
+		"--radius", "2500",
+		"--api-key", "test-key",
+		"--base-url", server.URL,
+		"--routes-base-url", server.URL,
+		"--json",
+	}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", exitCode, stderr.String())
+	}
+	if searchRadius != 2500 {
+		t.Fatalf("expected radius 2500 from --radius alias, got %v", searchRadius)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,7 +43,7 @@ type SearchCmd struct {
 	PriceLevel []int    `help:"Price levels 0-4. Repeatable."`
 	Lat        *float64 `help:"Latitude for location bias."`
 	Lng        *float64 `help:"Longitude for location bias."`
-	RadiusM    *float64 `help:"Radius in meters for location bias."`
+	RadiusM    *float64 `help:"Radius in meters for location bias." aliases:"radius"`
 }
 
 // AutocompleteCmd runs autocomplete queries.
@@ -55,7 +55,7 @@ type AutocompleteCmd struct {
 	Region       string   `help:"CLDR region code (e.g. US, DE)."`
 	Lat          *float64 `help:"Latitude for location bias."`
 	Lng          *float64 `help:"Longitude for location bias."`
-	RadiusM      *float64 `help:"Radius in meters for location bias."`
+	RadiusM      *float64 `help:"Radius in meters for location bias." aliases:"radius"`
 }
 
 // NearbyCmd runs nearby searches.
@@ -67,7 +67,7 @@ type NearbyCmd struct {
 	Region      string   `help:"CLDR region code (e.g. US, DE)."`
 	Lat         *float64 `help:"Latitude for location restriction."`
 	Lng         *float64 `help:"Longitude for location restriction."`
-	RadiusM     *float64 `help:"Radius in meters for location restriction."`
+	RadiusM     *float64 `help:"Radius in meters for location restriction." aliases:"radius"`
 }
 
 // DetailsCmd fetches place details.

--- a/internal/cli/route.go
+++ b/internal/cli/route.go
@@ -13,7 +13,7 @@ type RouteCmd struct {
 	From         string  `help:"Origin location (address or place name)."`
 	To           string  `help:"Destination location (address or place name)."`
 	Mode         string  `help:"Travel mode: DRIVE, WALK, BICYCLE, TWO_WHEELER, TRANSIT." default:"DRIVE"`
-	RadiusM      float64 `help:"Search radius in meters." default:"1000"`
+	RadiusM      float64 `help:"Search radius in meters." default:"1000" aliases:"radius"`
 	MaxWaypoints int     `help:"Max sampled waypoints along the route." default:"5"`
 	Limit        int     `help:"Max results per waypoint (1-20)." default:"5"`
 	Language     string  `help:"BCP-47 language code (e.g. en, en-US)."`


### PR DESCRIPTION
## Problem

The radius flag is spelled `--radius-m` on `search`, `nearby`, `autocomplete`, and `route`. Reaching for the natural `--radius` fails:

```
$ goplaces nearby --lat 37.7749 --lng -122.4194 --radius 500
unknown flag --radius, did you mean "--radius-m"?
```

The did-you-mean is helpful, but the flag is common enough that the extra round trip is just friction.

## Change

Kong `aliases:"radius"` on all four radius fields, so `--radius` and `--radius-m` resolve to the same value. `--radius-m` is unchanged and still documented as the primary spelling; nothing is renamed or deprecated.

Docs updated for `route`, `nearby`, and `autocomplete`, plus a changelog entry under 0.4.5.

## Tests

`TestRunRadiusAliasMatchesRadiusM` runs `search`, `nearby`, and `autocomplete` through `--radius-m`, `--radius`, and `--radius=1500`, asserting the radius reaches the right spot in the request payload (`locationBias.circle.radius` for search/autocomplete, `locationRestriction.circle.radius` for nearby). `TestRunRouteAcceptsRadiusAlias` covers `route` against a stubbed Routes + Places pair.

## Live verification

Verified against the real Places API (New) and Routes API, not just the mock:

- `search "coffee near Dolores Park San Francisco" --limit 3`
- `nearby --lat 37.7597 --lng -122.4269 --radius 400 --type cafe` (the alias)
- `nearby ... --radius-m 400` (original spelling, identical results)
- `route "coffee" --from "Dolores Park, San Francisco" --to "Ferry Building, San Francisco" --radius 300`
- `directions --from ... --to ... --mode DRIVE`
