### PR TITLE
fix(release): restore the 0.4.5 Unreleased marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.5 - 2026-08-23
+## 0.4.5 - Unreleased
 
 - CLI: accept `--radius` as an alias for `--radius-m` on `search`, `nearby`, `autocomplete`, and `route`.
 - Docs: validate generated llms metadata as plain text and keep the metadata helper import-safe. (#29) - thanks @vincentkoc


### PR DESCRIPTION
## Why

The 0.4.5 release gate rejects the changelog:

```
release-local: CHANGELOG must contain exactly one 0.4.5 - Unreleased section
```

`release-local` requires exactly one `## <version> - Unreleased` heading and rewrites it with the real date itself during the release, so a literal date in that heading makes the gate unsatisfiable.

## History

- `ffe0b0b` opened the section correctly as `## 0.4.5 - Unreleased`.
- `040749b` replaced the marker with a literal `2026-08-02` date.
- `#32` (mine) saw that stale date and refreshed it to `2026-08-23`, treating it as an out-of-date date rather than a marker that should never have been a date. That was the wrong fix.

This restores the marker. The publish step stamps the release date.
