### PR TITLE
fix(release): resolve the keychain domain in the Darwin signing hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Release: run credential-free release contract suites with the frozen jq 1.8.2 parser.
 - Release: refresh the reviewed release toolchain pins to GitHub CLI 2.98.0, GoReleaser 2.17.1, Node 26.7.0, and Python 3.14.7.
 - Release: accept the reviewed release-mac-app helper revision that scrubs package signing authority and narrows credential inheritance.
+- Release: resolve the signing account's keychain domain in the Darwin codesign hook so official signing works under the producer's isolated HOME.
 - CI: install the reviewed GitHub CLI before the release contract suite instead of inheriting the runner image's version.
 - Security: require Go 1.26.7 and scan both source and built binaries with pinned govulncheck. The 1.26.6 floor landed in #30 - thanks @vincentkoc
 - Build: update golangci-lint to 2.13.1 and staticcheck to 0.8.1 for Go 1.27 support.

--- a/scripts/codesign-macos.sh
+++ b/scripts/codesign-macos.sh
@@ -41,6 +41,18 @@ export PATH
 unset DEVELOPER_DIR SDKROOT TOOLCHAINS
 unset xcrun_log xcrun_nocache xcrun_verbose
 
+# codesign and notarytool resolve the signing identity through the account's
+# keychain domain, which is read from HOME. The release producer sandboxes HOME
+# for build isolation, so the tools would otherwise fail with "A default
+# keychain could not be found". Resolve the account's real home from the
+# account database and use it for the signing tools only; nothing else about
+# the isolated environment changes.
+login_home=$(/usr/bin/dscl . -read "/Users/$(/usr/bin/id -un)" NFSHomeDirectory 2>/dev/null | /usr/bin/awk '{print $2}')
+[[ -n "$login_home" && -d "$login_home" && "$login_home" == /* ]] ||
+  die "could not resolve the signing account home directory"
+HOME=$login_home
+export HOME
+
 test_mode=${GOPLACES_RELEASE_TEST_MODE-}
 test_tool_dir=${GOPLACES_RELEASE_TEST_TOOL_DIR-}
 if [[ "$test_mode" == "goplaces-release-contract-test-v1" ]]; then


### PR DESCRIPTION
## Problem

`codesign` and `notarytool` resolve the signing identity through the account's keychain domain, which is read from `HOME`. `release-local` runs GoReleaser with `HOME=\${git_isolation_root}/home` as part of its build isolation, so the signing hook failed after successfully building all six targets:

```
Error: An error occurred while accessing the keychain. A default keychain could not be found.
```

This is the first release to exercise the signing path, which landed after v0.4.4.

## Fix

Resolve the account's real home from the account database and export it for the signing tools in this hook only. Build isolation is otherwise untouched: the producer still runs the compiler and GoReleaser with its sandboxed `HOME`, `PATH`, and `TMPDIR`.

The helper-side equivalents were fixed in agent-scripts (`09393e8`, `d2e13af`), but they cannot cover this path: `release-local` sets `HOME` explicitly on the `env` that launches GoReleaser, so it overrides anything the helper passes to its child.

## Proof

All four release contract suites pass locally.