### PR TITLE
chore(release): cut 0.4.6 and retire the unpublished 0.4.5 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.4.5 - Unreleased
+## 0.4.6 - 2026-08-24
 
+- Release: 0.4.5 was tagged during release automation bring-up and never published; it carries the same code as this release.
 - CLI: accept `--radius` as an alias for `--radius-m` on `search`, `nearby`, `autocomplete`, and `route`.
 - Docs: validate generated llms metadata as plain text and keep the metadata helper import-safe. (#29) - thanks @vincentkoc
 - Docs: rewrite the README around verified install, quick-start, and reference paths.


### PR DESCRIPTION
The release flow requires the changelog marked `Unreleased` for `pilot` and dated for `draft`, with the tag created between those steps. v0.4.5 was tagged before the date was stamped, so its tag sits one commit behind where `draft` requires it.

The tag cannot be moved. Pushing it already caused proxy.golang.org to cache `v0.4.5 -> d7ea11f` and sum.golang.org to record its hashes, and both are immutable by design. Repointing the tag would leave anyone resolving with `GOPROXY=direct` facing a checksum mismatch against the sumdb, which surfaces as a security error rather than a benign retag.

So 0.4.6 is released from the dated commit and the v0.4.5 tag stays where it is: identical code, no published release, no dangling reference for the proxy.

Signing and notarization are already proven on this content: `release-local pilot v0.4.5` completed with exit 0, building all six targets and signing both Darwin binaries.