### PR TITLE
fix(release): correct three first-run release contract defects

### DIFF
--- a/scripts/check-release-verifier.sh
+++ b/scripts/check-release-verifier.sh
@@ -172,7 +172,7 @@ safe_json_id "$expected_run_id" || die "invalid expected run ID"
 [[ "$dispatch_nonce" =~ ^[0-9a-f]{64}$ ]] || die "EXPECTED_DISPATCH_NONCE is required"
 [[ "$state" == draft || "$state" == published ]] || die "invalid release state"
 [[ "$api_url" == https://api.github.com || ("$testing" == 1 && "${ALLOW_TEST_API_URL:-0}" == 1) ]] || die "unexpected GitHub API URL"
-[[ -n "${GH_TOKEN:-}" && "$GH_TOKEN" =~ ^[A-Za-z0-9_]+$ ]] || die "GH_TOKEN is required and must contain safe characters"
+[[ -n "${GH_TOKEN:-}" && "$GH_TOKEN" =~ ^[A-Za-z0-9_.-]+$ ]] || die "GH_TOKEN is required and must contain safe characters"
 proof_token="$GH_TOKEN"
 unset GH_TOKEN GITHUB_TOKEN
 [[ "$curl_bin" == /* && -f "$curl_bin" && ! -L "$curl_bin" && -x "$curl_bin" ]] || die "curl must be an absolute regular nonsymlink executable"

--- a/scripts/download-release-assets.sh
+++ b/scripts/download-release-assets.sh
@@ -127,7 +127,10 @@ if [[ "${#expected_release_id}" -gt 16 || ("${#expected_release_id}" -eq 16 && "
   die "release ID exceeds the maximum safe JSON integer"
 fi
 [[ -n "${GH_TOKEN:-}" ]] || die "GH_TOKEN is required only for this download operation"
-[[ "$GH_TOKEN" =~ ^[A-Za-z0-9_]+$ ]] || die "GH_TOKEN contains unsupported characters"
+# GitHub Actions now issues JWT-style tokens: base64url segments (which use
+# - and _) joined by dots. Allow exactly that set; whitespace, quotes, and
+# shell metacharacters remain rejected.
+[[ "$GH_TOKEN" =~ ^[A-Za-z0-9_.-]+$ ]] || die "GH_TOKEN contains unsupported characters"
 download_token="$GH_TOKEN"
 unset GH_TOKEN GITHUB_TOKEN
 [[ "$curl_bin" == /* && -f "$curl_bin" && ! -L "$curl_bin" && -x "$curl_bin" ]] || die "curl must be an absolute regular nonsymlink executable"

--- a/scripts/release-local
+++ b/scripts/release-local
@@ -471,13 +471,13 @@ run_protected_script() {
     fi
   done
   if [[ -n "${GH_TOKEN+x}" ]]; then
-    [[ "$GH_TOKEN" =~ ^[A-Za-z0-9_]+$ ]] || die "protected helper token is empty or unsafe"
+    [[ "$GH_TOKEN" =~ ^[A-Za-z0-9_.-]+$ ]] || die "protected helper token is empty or unsafe"
     secret_token="$GH_TOKEN"
     if printf '%s\n' "$secret_token" | /usr/bin/env -i -C "$protected_source_root" \
       "${forwarded_environment[@]}" \
       PATH="$CLEAN_SYSTEM_PATH" HOME="${git_isolation_root}/home" TMPDIR="${git_isolation_root}/tmp" LC_ALL=C TZ=UTC \
       GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_NO_REPLACE_OBJECTS=1 GIT_TERMINAL_PROMPT=0 \
-      /bin/bash -p -c 'IFS= read -r GH_TOKEN; [[ "$GH_TOKEN" =~ ^[A-Za-z0-9_]+$ ]] || exit 97; export GH_TOKEN; exec "$@"' \
+      /bin/bash -p -c 'IFS= read -r GH_TOKEN; [[ "$GH_TOKEN" =~ ^[A-Za-z0-9_.-]+$ ]] || exit 97; export GH_TOKEN; exec "$@"' \
       _ "$script" "$@"; then
       command_status=0
     else
@@ -701,7 +701,7 @@ gh_api() {
     /bin/mkdir -p "${git_isolation_root}/gh-config"
     /bin/chmod 700 "${git_isolation_root}/gh-config"
     token=$(gh_auth_token) || die "could not obtain GitHub authentication"
-    [[ "$token" =~ ^[A-Za-z0-9_]+$ ]] || die "GitHub authentication token is empty or unsafe"
+    [[ "$token" =~ ^[A-Za-z0-9_.-]+$ ]] || die "GitHub authentication token is empty or unsafe"
     /usr/bin/env -i PATH="$CLEAN_SYSTEM_PATH" HOME="${git_isolation_root}/home" GH_CONFIG_DIR="${git_isolation_root}/gh-config" \
       TMPDIR="${git_isolation_root}/tmp" LC_ALL=C TZ=UTC \
       /bin/bash -p -c 'IFS= read -r GH_TOKEN <&3; exec 3<&-; export GH_TOKEN; exec "$@"' \
@@ -747,7 +747,7 @@ gh_watch_run() {
     /bin/mkdir -p "${git_isolation_root}/gh-config"
     /bin/chmod 700 "${git_isolation_root}/gh-config"
     token=$(gh_auth_token) || die "could not obtain GitHub authentication"
-    [[ "$token" =~ ^[A-Za-z0-9_]+$ ]] || die "GitHub authentication token is empty or unsafe"
+    [[ "$token" =~ ^[A-Za-z0-9_.-]+$ ]] || die "GitHub authentication token is empty or unsafe"
     /usr/bin/env -i PATH="$CLEAN_SYSTEM_PATH" HOME="${git_isolation_root}/home" GH_CONFIG_DIR="${git_isolation_root}/gh-config" \
       TMPDIR="${git_isolation_root}/tmp" LC_ALL=C TZ=UTC \
       /bin/bash -p -c 'IFS= read -r GH_TOKEN <&3; exec 3<&-; export GH_TOKEN; exec "$@"' \
@@ -1317,7 +1317,9 @@ canonical_release_record() {
       select(.name == $tag) |
       select(.prerelease == false) |
       select(wanted_state) |
-      select(.body == $notes) |
+      # GitHub normalizes a release body by appending a single trailing
+      # newline, so accept exactly that and nothing looser.
+      select(.body == $notes or .body == ($notes + "\n")) |
       select((.assets | map(.name) | sort) == $expected_assets) |
       select((.assets | map(.id) | unique | length) == 7) |
       select(all(.assets[];
@@ -1327,7 +1329,15 @@ canonical_release_record() {
         (.state == "uploaded") and
         (.digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
         (.url == ("https://api.github.com/repos/" + $repo + "/releases/assets/" + (.id | tostring))) and
-        (.browser_download_url == ("https://github.com/" + $repo + "/releases/download/" + $tag + "/" + .name))
+        (. as $asset |
+          if $state == "draft" then
+            # A draft has no tag association yet, so GitHub serves an
+            # untagged-<hex> placeholder segment instead of the tag.
+            ($asset.browser_download_url | startswith("https://github.com/" + $repo + "/releases/download/untagged-")) and
+            ($asset.browser_download_url | endswith("/" + $asset.name))
+          else
+            $asset.browser_download_url == ("https://github.com/" + $repo + "/releases/download/" + $tag + "/" + $asset.name)
+          end)
       )) |
       {
         schema:"goplaces-release-record-v1", repository:$repo, state:$state,
@@ -2190,7 +2200,7 @@ run_codesigned_goreleaser() {
       fi
       ;;
     draft)
-      [[ "$draft_github_token" =~ ^[A-Za-z0-9_]+$ ]] || die "draft GitHub authentication token is empty or unsafe"
+      [[ "$draft_github_token" =~ ^[A-Za-z0-9_.-]+$ ]] || die "draft GitHub authentication token is empty or unsafe"
       draft_auth="$draft_github_token"
       if [[ "${GOPLACES_RELEASE_LOCAL_TESTING:-0}" == 1 ]]; then
         "${clean_outer_environment[@]}" \
@@ -2260,7 +2270,7 @@ run_draft() {
     verify_remote_tag "$tag" "$default_sha"
     recheck_source_default
     draft_github_token=$(gh_auth_token) || die "could not obtain GitHub authentication for draft creation"
-    [[ "$draft_github_token" =~ ^[A-Za-z0-9_]+$ ]] || die "draft GitHub authentication token is empty or unsafe"
+    [[ "$draft_github_token" =~ ^[A-Za-z0-9_.-]+$ ]] || die "draft GitHub authentication token is empty or unsafe"
     verify_remote_tag "$tag" "$default_sha"
     recheck_source_default
     run_codesigned_goreleaser "$source" draft "$tag" \
@@ -2466,7 +2476,7 @@ download_release_copy() {
   unset token
   [[ "$output_record" == "${destination}/release-record.json" ]] || die "asset downloader returned an unexpected record path"
   run_protected_script scripts/validate-release-record.sh "$output_record" "$tag" "$default_sha" "$state" >/dev/null
-  jq -e --rawfile notes "$notes" '.body == $notes' "$output_record" >/dev/null || die "downloaded release notes differ from tagged changelog bytes"
+  jq -e --rawfile notes "$notes" '.body == $notes or .body == ($notes + "\n")' "$output_record" >/dev/null || die "downloaded release notes differ from tagged changelog bytes"
 }
 
 compare_release_copies() {

--- a/scripts/test-release-local.sh
+++ b/scripts/test-release-local.sh
@@ -637,13 +637,19 @@ make_release_fixture() {
     "goplaces_${version}_windows_arm64.zip"
     goplaces_checksums.txt
   )
+  # A draft has no tag association yet, so GitHub serves an untagged-<hex>
+  # placeholder segment in browser_download_url instead of the tag.
+  local browser_segment="v0.4.5"
+  if [[ "$draft" == "true" ]]; then
+    browser_segment="untagged-bfe67b1c39b7ef63c1dc"
+  fi
   printf '[]\n' > "${output}.assets"
   for name in "${names[@]}"; do
     index=$((index + 1))
     jq \
       --argjson id "$((1000 + index))" --arg name "$name" --argjson size "$((2000 + index))" --arg digest "$digest" \
       --arg api "https://api.github.com/repos/openclaw/goplaces/releases/assets/$((1000 + index))" \
-      --arg browser "https://github.com/openclaw/goplaces/releases/download/v0.4.5/${name}" \
+      --arg browser "https://github.com/openclaw/goplaces/releases/download/${browser_segment}/${name}" \
       '. + [{id:$id,name:$name,size:$size,digest:$digest,url:$api,browser_download_url:$browser,content_type:"application/octet-stream",state:"uploaded",created_at:"2026-07-10T10:00:00Z",updated_at:"2026-07-10T10:00:00Z"}]' \
       "${output}.assets" > "${output}.next"
     mv "${output}.next" "${output}.assets"


### PR DESCRIPTION
The signed publication path landed after v0.4.4 and 0.4.5/0.4.6 were the first attempts to run it end to end. It asserts three things GitHub does not actually do.

## 1. Release body trailing newline

GitHub appends a single trailing newline to a release body, so `.body == $notes` can never hold. Measured against the real draft: `body == notes + "\n"` exactly. Now accepts the notes with an optional single trailing newline and nothing looser.

## 2. Draft asset URLs

A draft has no tag association, so GitHub serves every asset's `browser_download_url` with an `untagged-<hex>` placeholder instead of the tag:

```
.../releases/download/untagged-bfe67b1c39b7ef63c1dc/goplaces_0.4.6_darwin_amd64.tar.gz
```

Requiring the tag there made every draft unverifiable. The check is now state-aware: placeholder form for drafts, exact tag form once published. The contract fixture models both shapes rather than only the published one.

## 3. Token charset

The verifier failed with `GH_TOKEN contains unsupported characters`. GitHub Actions now issues JWT-style tokens: base64url segments (which use `-` and `_`) joined by dots. Measured on a live runner without revealing the value: 3 characters outside the old set, dots and dashes only, zero residual, length ~370.

Widened to `[A-Za-z0-9_.-]` across the eight places that share this check. Whitespace, quotes, control characters and shell metacharacters remain rejected, which is the property the check exists for.

## Proof

All four release contract suites pass. Fixes 1 and 2 were verified by running the real `validate-release-record.sh` against a canonical record built from the actual v0.4.6 draft (rc=0).