### PR TITLE
fix(release): match redirect headers without awk IGNORECASE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Release: accept the reviewed release-mac-app helper revision that scrubs package signing authority and narrows credential inheritance.
 - Release: resolve the signing account's keychain domain in the Darwin codesign hook so official signing works under the producer's isolated HOME.
 - Release: accept GitHub's release-body newline normalization, the untagged asset URLs GitHub serves for drafts, and its JWT-style Actions tokens.
+- Release: match redirect headers without awk IGNORECASE so asset downloads work under the macOS awk the verifier runs on.
 - CI: install the reviewed GitHub CLI before the release contract suite instead of inheriting the runner image's version.
 - Security: require Go 1.26.7 and scan both source and built binaries with pinned govulncheck. The 1.26.6 floor landed in #30 - thanks @vincentkoc
 - Build: update golangci-lint to 2.13.1 and staticcheck to 0.8.1 for Go 1.27 support.

--- a/scripts/check-release-verifier.sh
+++ b/scripts/check-release-verifier.sh
@@ -240,9 +240,9 @@ download_logs() {
     return
   fi
   [[ "$status" == 302 ]] || die "verifier log API returned unexpected HTTP $status"
-  redirect_count="$(/usr/bin/awk 'BEGIN {IGNORECASE=1} /^Location:[[:space:]]/ {count++} END {print count + 0}' "$headers")"
+  redirect_count="$(/usr/bin/awk '{ if (tolower($0) ~ /^location:[[:space:]]/) count++ } END {print count + 0}' "$headers")"
   [[ "$redirect_count" -eq 1 ]] || die "verifier log API returned an ambiguous redirect"
-  redirect_url="$(/usr/bin/awk 'BEGIN {IGNORECASE=1} /^Location:[[:space:]]/ {sub(/\r$/, ""); sub(/^[^:]*:[[:space:]]*/, ""); print}' "$headers")"
+  redirect_url="$(/usr/bin/awk '{ if (tolower($0) ~ /^location:[[:space:]]/) { sub(/\r$/, ""); sub(/^[^:]*:[[:space:]]*/, ""); print } }' "$headers")"
   case "$redirect_url" in
     https://*.blob.core.windows.net/*|https://results-receiver.actions.githubusercontent.com/*) ;;
     *) die "verifier log API redirected to an unapproved HTTPS host" ;;

--- a/scripts/download-release-assets.sh
+++ b/scripts/download-release-assets.sh
@@ -235,9 +235,9 @@ download_asset() {
     return
   fi
   [[ "$status" == 302 ]] || die "asset API returned unexpected HTTP $status"
-  redirect_count="$(/usr/bin/awk 'BEGIN {IGNORECASE=1} /^Location:[[:space:]]/ {count++} END {print count + 0}' "$headers")"
+  redirect_count="$(/usr/bin/awk '{ if (tolower($0) ~ /^location:[[:space:]]/) count++ } END {print count + 0}' "$headers")"
   [[ "$redirect_count" -eq 1 ]] || die "asset API returned an ambiguous redirect"
-  redirect_url="$(/usr/bin/awk 'BEGIN {IGNORECASE=1} /^Location:[[:space:]]/ {sub(/\r$/, ""); sub(/^[^:]*:[[:space:]]*/, ""); print}' "$headers")"
+  redirect_url="$(/usr/bin/awk '{ if (tolower($0) ~ /^location:[[:space:]]/) { sub(/\r$/, ""); sub(/^[^:]*:[[:space:]]*/, ""); print } }' "$headers")"
   case "$redirect_url" in
     https://release-assets.githubusercontent.com/*) ;;
     *) die "asset API redirected to an unapproved HTTPS host" ;;


### PR DESCRIPTION
## Problem

Every verifier asset download failed:

```
release asset download: asset API returned an ambiguous redirect
```

The downloader counts and extracts the redirect target with:

```sh
awk 'BEGIN {IGNORECASE=1} /^Location:[[:space:]]/ ...'
```

`IGNORECASE` is a **GNU awk extension**. macOS ships BWK awk (`awk version 20200816`), which silently ignores it. HTTP/2 sends lowercase header names, so `/^Location:/` never matches, the count is always 0, and the `-eq 1` guard reports an ambiguous redirect. The verifier jobs run on macOS, so this could never have worked there.

## Measured, not guessed

Against the live asset API for a real draft asset:

| probe | result |
| --- | --- |
| `http_code` | 302 |
| HTTP status lines in dump | 1 |
| `awk` with `IGNORECASE=1` counting `^Location:` | **0** |
| `grep -ci '^location:'` | **1** |
| exact-case `^Location:` | 0 |
| lowercase `^location:` | 1 |

So the header is present and singular; only the matcher was broken.

## Fix

Match with `tolower($0) ~ /^location:[[:space:]]/`, which is portable across BWK and GNU awk. Applied to both the count and the URL extraction, in `download-release-assets.sh` and `check-release-verifier.sh`.

Verified after the change: count is 1 and the extracted URL resolves to `https://release-assets.githubusercontent.com`.

All four release contract suites pass.