### PR TITLE
chore(release): cut 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.4.7 - 2026-08-24
+## 0.4.8 - 2026-08-24
 
-- Release: 0.4.5 and 0.4.6 were tagged during release automation bring-up and never published; they carry the same code as this release.
+- Release: 0.4.5, 0.4.6 and 0.4.7 were tagged while bringing up the signed release automation and were never published; they carry the same code as this release.
 - CLI: accept `--radius` as an alias for `--radius-m` on `search`, `nearby`, `autocomplete`, and `route`.
 - Docs: validate generated llms metadata as plain text and keep the metadata helper import-safe. (#29) - thanks @vincentkoc
 - Docs: rewrite the README around verified install, quick-start, and reference paths.


### PR DESCRIPTION
0.4.7 could not be published. `verify-draft` surfaced the awk `IGNORECASE` portability defect fixed in #44, and that fix moved `main` past the tag. The tag could not follow: `v0.4.7` was already cached by proxy.golang.org at `610ccf3`, and repointing a cached version breaks `GOPROXY=direct` resolution against the sumdb.

0.4.8 releases from the fixed commit. `v0.4.5`, `v0.4.6` and `v0.4.7` keep their tags at exactly the commits the proxy recorded, so the proxy and GitHub agree on all three; none has a published release, and all carry the same code as this one.

## Path status

Each stage is now exercised against real data rather than assumed:

| stage | status |
| --- | --- |
| `--check` | passes (govulncheck clean, six-target reproducible build byte-identical) |
| `pilot` | exit 0, both Darwin binaries signed and notarized |
| `draft` | exit 0, all seven assets uploaded, record validation passes |
| `verify-draft` download | fixed in #44 and verified against the live asset API |
| `verify-draft` later stages | first run pending |