### PR TITLE
fix(release): compare distinct verifier proof markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Release: resolve the signing account's keychain domain in the Darwin codesign hook so official signing works under the producer's isolated HOME.
 - Release: accept GitHub's release-body newline normalization, the untagged asset URLs GitHub serves for drafts, and its JWT-style Actions tokens.
 - Release: match redirect headers without awk IGNORECASE so asset downloads work under the macOS awk the verifier runs on.
+- Release: compare distinct verifier proof markers, since a run log archive repeats every line in both its aggregated and per-step entries.
 - CI: install the reviewed GitHub CLI before the release contract suite instead of inheriting the runner image's version.
 - Security: require Go 1.26.7 and scan both source and built binaries with pinned govulncheck. The 1.26.6 floor landed in #30 - thanks @vincentkoc
 - Build: update golangci-lint to 2.13.1 and staticcheck to 0.8.1 for Go 1.27 support.

--- a/scripts/check-release-verifier.sh
+++ b/scripts/check-release-verifier.sh
@@ -351,9 +351,16 @@ unzip_run -p "$logs_zip" > "$logs_txt" || die "could not read verifier logs"
 proof_inventory_digest=""
 for proof_arch in arm64 x86_64; do
   marker_prefix="GOPLACES_RELEASE_PROOF_V1 arch=$proof_arch run_id=$selected_id tag=$tag tag_object=$expected_tag_object tag_commit=$expected_tag_commit release_id=$release_id default_sha=$expected_main inventory_sha256="
-  [[ "$(/usr/bin/grep -Fc "$marker_prefix" "$logs_txt")" -eq 1 ]] || die "missing or duplicate $proof_arch proof marker"
-  /usr/bin/grep -E "${marker_prefix}[0-9a-f]{64}$" "$logs_txt" >/dev/null || die "$proof_arch proof marker has an invalid inventory digest"
-  marker_line="$(/usr/bin/grep -F "$marker_prefix" "$logs_txt")"
+  # A run log archive carries each line twice: once in the aggregated
+  # 0_<job>.txt and once in the per-step <job>/<n>_<step> entry, and unzip -p
+  # concatenates both. Compare distinct marker lines with the leading ISO
+  # timestamp removed so the "exactly one marker" contract still holds.
+  marker_lines="$(/usr/bin/grep -F "$marker_prefix" "$logs_txt" |
+    /usr/bin/sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z //' |
+    /usr/bin/sort -u)"
+  [[ "$(printf '%s' "$marker_lines" | /usr/bin/grep -c .)" -eq 1 ]] || die "missing or duplicate $proof_arch proof marker"
+  printf '%s\n' "$marker_lines" | /usr/bin/grep -E "^${marker_prefix}[0-9a-f]{64}$" >/dev/null || die "$proof_arch proof marker has an invalid inventory digest"
+  marker_line="$marker_lines"
   current_digest="${marker_line##*inventory_sha256=}"
   [[ "$current_digest" =~ ^[0-9a-f]{64}$ ]] || die "$proof_arch inventory digest is invalid"
   if [[ -z "$proof_inventory_digest" ]]; then


### PR DESCRIPTION
## Problem

Both verifier jobs passed every stage, then the local check rejected the result:

```
release verifier check: missing or duplicate arm64 proof marker
```

The check requires exactly one `GOPLACES_RELEASE_PROOF_V1` marker per architecture in the downloaded run log. A GitHub run log archive stores every line **twice**: once in the aggregated `0_<job>.txt` entry and once in the per-step `<job>/<n>_<step>` entry. `unzip -p` concatenates all entries, so the count is always 2 and the `-eq 1` guard can never pass.

## Measured

On the v0.4.8 verifier run (32697716754):

| arch | raw matches | distinct after timestamp strip | digest valid |
| --- | --- | --- | --- |
| arm64 | 2 | 1 | yes |
| x86_64 | 2 | 1 | yes |

The duplicate lines are byte-identical, and both architectures bind the same inventory digest `0a1f3157…48cb`, which is what the cross-arch check exists to confirm.

## Fix

Compare distinct marker lines with the leading ISO timestamp removed. The contract is unchanged: exactly one marker per architecture, both binding one inventory. Duplication introduced by GitHub's log packaging no longer counts as a second marker.

All four release contract suites pass.