### PR TITLE
chore(release): cut 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.4.8 - 2026-08-24
+## 0.4.9 - 2026-08-24
 
-- Release: 0.4.5, 0.4.6 and 0.4.7 were tagged while bringing up the signed release automation and were never published; they carry the same code as this release.
+- Release: 0.4.5 through 0.4.8 were tagged while bringing up the signed release automation and were never published; they carry the same code as this release.
 - CLI: accept `--radius` as an alias for `--radius-m` on `search`, `nearby`, `autocomplete`, and `route`.
 - Docs: validate generated llms metadata as plain text and keep the metadata helper import-safe. (#29) - thanks @vincentkoc
 - Docs: rewrite the README around verified install, quick-start, and reference paths.


### PR DESCRIPTION
0.4.8 could not be published. Both verifier jobs passed every stage, but the local proof-marker check rejected the result because a GitHub run log archive repeats every line in both its aggregated and per-step entries (fixed in #46). That fix moved `main` past the tag, and `v0.4.8` was already cached by proxy.golang.org at `cee1bda`.

0.4.9 releases from the fixed commit. The `v0.4.5` through `v0.4.8` tags stay at exactly the commits the proxy recorded, so the proxy and GitHub agree on each; none has a published release, and all carry the same code as this one.

## Path status

| stage | status |
| --- | --- |
| `--check` | passes |
| `pilot` | exit 0, Darwin binaries signed and notarized |
| `draft` | exit 0, seven assets uploaded, record validation passes |
| `verify-draft` remote jobs | both arches passed every stage, one shared inventory digest |
| `verify-draft` proof check | fixed in #46, verified against the real run log |
| `publish` / `homebrew` | first run pending |